### PR TITLE
Remove metalite from `Remotes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,6 @@ Suggests:
     readxl,
     rprojroot,
     testthat (>= 3.0.0)
-Remotes:
-    Merck/metalite
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
 Config/testthat/edition: 3
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# metalite.ae 
+# metalite.ae
 
 <!-- badges: start -->
 
@@ -11,21 +11,21 @@
 
 ## Overview
 
-`metalite.ae` is an R package for standard adverse events analysis including: 
+metalite.ae is an R package for standard adverse events analysis, including:
 
-- AE summary 
-- Specific AE analysis 
+- AE summary.
+- Specific AE analysis.
 
-## Workflow 
+## Workflow
 
-The general workflow is splited into three parts. 
+The general workflow is split into three parts.
 
-1. define meta data information using `metalite` package 
-1. prepare outdata using `prepare_xxx` functions 
-1. create TLFs using `tlf_xxx` functions 
+1. Define meta data information using the metalite package.
+1. Prepare outdata using `prepare_*()` functions.
+1. Create TLFs using `tlf_*()` functions.
 
 ## Highlighted features
 
-- enable meta data structure 
-- consistent input and output in standard functions
-- streamline mock table generation
+- Enables metadata structure.
+- Consistent input and output in standard functions.
+- Streamlines mock table generation.

--- a/vignettes/metalite-ae.Rmd
+++ b/vignettes/metalite-ae.Rmd
@@ -26,22 +26,22 @@ library(metalite.ae)
 
 ## Overview
 
-`metalite.ae` is an R package for standard adverse events analysis including:
+metalite.ae is an R package for standard adverse events analysis, including:
 
-- AE summary
-- Specific AE analysis
-- Specific AE subgroup analysis (TODO)
-- AE listing (TODO)
+- AE summary.
+- Specific AE analysis.
+- Specific AE subgroup analysis (TODO).
+- AE listing (TODO).
 
 ### Workflow
 
-The general workflow is splitted into three parts.
+The general workflow is split into three parts.
 
-1. Define meta data information using `metalite` package
-1. Prepare outdata using `prepare_xxx` functions
-1. Extend outdata using `extend_xxx` functions
-1. Format outdata using `format_xxx` functions
-1. Create TLFs using `tlf_xxx` functions
+1. Define metadata information using the metalite package.
+1. Prepare outdata using `prepare_*()` functions.
+1. Extend outdata using `extend_*()` functions.
+1. Format outdata using `format_*()` functions.
+1. Create TLFs using `tlf_*()` functions.
 
 For example, we can create a simple AE summary table as below.
 
@@ -67,6 +67,6 @@ More examples can be found in `vignette("ae-summary")` and `vignette("ae-specifi
 
 ### Highlighted features
 
-- Enable metadata structure
-- Consistent input and output in standard functions
-- Streamline mock table generation
+- Enables metadata structure.
+- Consistent input and output in standard functions.
+- Streamlines mock table generation.


### PR DESCRIPTION
This PR:

- Removed metalite from `Remotes` field as it's now on CRAN.
- Updated function name placeholder format to `prefix_*()`, following the _R Packages_ book.
- Use colon, capitalization, and full stops for bulleted lists, following the [tidyverse style guide](https://style.tidyverse.org/documentation.html#capitalization-and-full-stops).