### PR TITLE
Fix all check notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,15 +21,14 @@ Encoding: UTF-8
 VignetteBuilder: knitr
 Depends: R (>= 4.1.0)
 Imports:
-    DescTools,
     dplyr,
     glue,
     metalite,
     r2rtf,
     stats,
-    tidyr,
-    haven
+    tidyr
 Suggests:
+    DescTools,
     covr,
     knitr,
     kableExtra,

--- a/R/extend_ae_specific.R
+++ b/R/extend_ae_specific.R
@@ -37,6 +37,8 @@ extend_ae_specific_inference <- function(outdata,
   ci_upper <- list()
   p <- list()
 
+  bind_rows2 <- utils::getFromNamespace("bind_rows2", ns = "metalite")
+
   for (iter in 1:length(grp)) {
     index <- grp[iter]
     x0 <- res$n[[ref]]
@@ -54,7 +56,7 @@ extend_ae_specific_inference <- function(outdata,
         n1 = n1[i], alpha = 1 - ci
       )
     }
-    tmp <- metalite:::bind_rows2(tmp)
+    tmp <- bind_rows2(tmp)
     ci_lower[[iter]] <- tmp$lower
     ci_upper[[iter]] <- tmp$upper
     p[[iter]] <- tmp$p

--- a/R/prepare_ae_specific.R
+++ b/R/prepare_ae_specific.R
@@ -170,7 +170,7 @@ prepare_ae_specific <- function(meta,
   tbl_diff <- tbl_diff[-c(reference_group, n_group)]
 
   # Return value
-  metalite:::outdata(meta, population, observation, parameter,
+  metalite::outdata(meta, population, observation, parameter,
     n = tbl_num, order = tbl$order, group = u_group, reference_group = reference_group,
     prop = tbl_rate, diff = tbl_diff,
     n_pop = tbl_num[1, ],

--- a/R/prepare_ae_summary.R
+++ b/R/prepare_ae_summary.R
@@ -88,7 +88,7 @@ if("any" %in% parameters){
   names(res) <- NULL
 }
 
-  metalite:::outdata(meta, population, observation, parameter,
+  metalite::outdata(meta, population, observation, parameter,
     n = rbind(n_pop, tbl_num),
     order = c(1, 1:nrow(tbl_num) * 100),
     group = res[[1]]$group,

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -116,12 +116,12 @@ tlf_ae_listing <- function(outdata,
   # Using r2rtf
 
   outdata$rtf <- res |>
-    rtf_page(orientation =  orientation) |>
-    rtf_title(title)  |>
-    rtf_colheader(colheader,
+    r2rtf::rtf_page(orientation =  orientation) |>
+    r2rtf::rtf_title(title)  |>
+    r2rtf::rtf_colheader(colheader,
                   col_rel_width = rel_width1,
                   text_font_size = text_font_size) |>
-    rtf_body(
+    r2rtf::rtf_body(
       col_rel_width = rel_width,
       text_justification = text_justification,
       text_format = text_format,

--- a/tests/testthat/test-independent-testing-prepare_ae_specificr.R
+++ b/tests/testthat/test-independent-testing-prepare_ae_specificr.R
@@ -1,7 +1,6 @@
 
 library(metalite.ae)
 library(metalite)
-library(haven)
 library(dplyr)
 library(tidyr)
 

--- a/tests/testthat/test-independent-testing-prepare_ae_summary.R
+++ b/tests/testthat/test-independent-testing-prepare_ae_summary.R
@@ -17,7 +17,6 @@
 
 library(metalite.ae)
 library(metalite)
-library(haven)
 library(dplyr)
 library(tidyr)
 library(testthat)


### PR DESCRIPTION
This PR:

- Removed haven from `Imports` and tests as it's not actually used.
- Moved DescTools to `Suggests` as it's only used in tests.
- Use `::` to call `metalite::outdata()` as it's an exported function.
- Update the approach to call `metalite:::bind_rows2()`.
- Added `r2rtf::` to some r2rtf functions that are not explicitly imported, following the existing style.

It fixes all the current R CMD check notes, listed below:

```
* checking dependencies in R code ... NOTE
Namespaces in Imports field not imported from:
  ‘DescTools’ ‘haven’
  All declared Imports should be used.

':::' call which should be '::': ‘metalite:::outdata’
  See the note in ?`:::` about the use of this operator.

Unexported object imported by a ':::' call: ‘metalite:::bind_rows2’
  See the note in ?`:::` about the use of this operator.

* checking R code for possible problems ... NOTE
tlf_ae_listing: no visible global function definition for ‘rtf_body’
tlf_ae_listing: no visible global function definition for ‘rtf_colheader’
tlf_ae_listing: no visible global function definition for ‘rtf_title’
tlf_ae_listing: no visible global function definition for ‘rtf_page’
Undefined global functions or variables:
  rtf_body rtf_colheader rtf_page rtf_title
```