### PR TITLE
`medra` -> `meddra`; use sentence case for `@param` values

### DIFF
--- a/R/extend_ae_specific.R
+++ b/R/extend_ae_specific.R
@@ -205,7 +205,7 @@ extend_ae_specific_duration <- function(outdata,
 
 #' Add average number of events information for AE specific analysis
 #'
-#' @param outdata A `outdata` object created by [prepare_ae_specific()]
+#' @param outdata A `outdata` object created by [prepare_ae_specific()].
 #'
 #' @return To be added.
 #'

--- a/R/fmt.R
+++ b/R/fmt.R
@@ -89,7 +89,7 @@ fmt_est <- function(mean,
 #' Format confidence interval
 #'
 #' @param lower A numeric value of lower value of CI.
-#' @param upper A numeric value of lower value of CI.
+#' @param upper A numeric value of upper value of CI.
 #' @param digits Digits of each column, i.e., format as (x.x, x.x).
 #' @param width Width of each column.
 #'

--- a/R/prepare_ae_listing.R
+++ b/R/prepare_ae_listing.R
@@ -18,14 +18,14 @@
 
 #' Prepare datasets for AE specific analysis
 #'
-#' @param meta a meta data created by `metalite`.
-#' @param analysis analysis name from `meta`
-#' @param population a character value of population term name.
-#' The term name is used as key to link information.
-#' @param observation a character value of observation term name.
-#' The term name is used as key to link information.
-#' @param parameter a character value of parameter term name.
-#' The term name is used as key to link information.
+#' @param meta A metadata object created by metalite.
+#' @param analysis Analysis name from `meta`.
+#' @param population A character value of population term name.
+#'   The term name is used as key to link information.
+#' @param observation A character value of observation term name.
+#'   The term name is used as key to link information.
+#' @param parameter A character value of parameter term name.
+#'   The term name is used as key to link information.
 #'
 #' @return To be added.
 #'

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -18,13 +18,13 @@
 
 #' Specific adverse events table
 #'
-#' @param outdata a outdata list created from `prepare_ae_listing`
-#' @param footnotes a character vector of table footnotes
-#' @param source a character value of the data source
+#' @param outdata A outdata list created by [prepare_ae_listing()].
+#' @param footnotes A character vector of table footnotes.
+#' @param source A character value of the data source.
 #' @inheritParams r2rtf::rtf_page
 #' @inheritParams r2rtf::rtf_body
-#' @param path_outdata a character string of the outdata path
-#' @param path_outtable a character string of the outtable path
+#' @param path_outdata A character string of the outdata path.
+#' @param path_outtable A character string of the outtable path.
 #'
 #' @return To be added.
 #'

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -18,15 +18,16 @@
 
 #' Specific adverse events table
 #'
-#' @param outdata a outdata list created from `prepare_ae_specific`
-#' @param medra_version a character value of the MedDRA Version for this dataset
-#' @param source a character value of the data source
+#' @param outdata A outdata list created from [prepare_ae_specific()].
+#' @param meddra_version A character value of the MedDRA version
+#'   for this dataset.
+#' @param source A character value of the data source.
 #' @inheritParams r2rtf::rtf_page
 #' @inheritParams r2rtf::rtf_body
-#' @param footnotes a character vector of table footnotes
-#' @param title a character vector of table titles
-#' @param path_outdata a character string of the outdata path
-#' @param path_outtable a character string of the outtable path
+#' @param footnotes A character vector of table footnotes.
+#' @param title A character vector of table titles.
+#' @param path_outdata A character string of the outdata path.
+#' @param path_outtable A character string of the outtable path.
 #'
 #' @return To be added.
 #'
@@ -44,12 +45,12 @@
 #'   format_ae_specific() |>
 #'   tlf_ae_specific(
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-#'     medra_version = "24.0",
+#'     meddra_version = "24.0",
 #'     path_outdata = tempfile(fileext = ".Rdata"),
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
 tlf_ae_specific <- function(outdata,
-                            medra_version,
+                            meddra_version,
                             source,
                             col_rel_width = NULL,
                             text_font_size = 9,
@@ -66,7 +67,7 @@ tlf_ae_specific <- function(outdata,
         "its incidence in one or more of the columns meets the incidence",
         "criterion in the report title, after rounding."
       ),
-      "Adverse event terms are from MedDRA Version {medra_version}."
+      "Adverse event terms are from MedDRA Version {meddra_version}."
     )
   }
 
@@ -100,7 +101,7 @@ tlf_ae_specific <- function(outdata,
   }
 
   footnotes <- vapply(footnotes, glue::glue_data,
-    .x = list(medra_version = medra_version), FUN.VALUE = character(1)
+    .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
   )
   names(footnotes) <- NULL
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ metalite.ae is an R package for standard adverse events analysis, including:
 
 The general workflow is split into three parts.
 
-1. Define meta data information using the metalite package.
+1. Define metadata information using the metalite package.
 1. Prepare outdata using `prepare_*()` functions.
 1. Create TLFs using `tlf_*()` functions.
 

--- a/man/extend_ae_specific_events.Rd
+++ b/man/extend_ae_specific_events.Rd
@@ -7,7 +7,7 @@
 extend_ae_specific_events(outdata)
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}}
+\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 }
 \value{
 To be added.

--- a/man/fmt_ci.Rd
+++ b/man/fmt_ci.Rd
@@ -9,7 +9,7 @@ fmt_ci(lower, upper, digits = 2, width = 3 + digits)
 \arguments{
 \item{lower}{A numeric value of lower value of CI.}
 
-\item{upper}{A numeric value of lower value of CI.}
+\item{upper}{A numeric value of upper value of CI.}
 
 \item{digits}{Digits of each column, i.e., format as (x.x, x.x).}
 

--- a/man/prepare_ae_listing.Rd
+++ b/man/prepare_ae_listing.Rd
@@ -7,17 +7,17 @@
 prepare_ae_listing(meta, analysis, population, observation, parameter)
 }
 \arguments{
-\item{meta}{a meta data created by \code{metalite}.}
+\item{meta}{A metadata object created by metalite.}
 
-\item{analysis}{analysis name from \code{meta}}
+\item{analysis}{Analysis name from \code{meta}.}
 
-\item{population}{a character value of population term name.
+\item{population}{A character value of population term name.
 The term name is used as key to link information.}
 
-\item{observation}{a character value of observation term name.
+\item{observation}{A character value of observation term name.
 The term name is used as key to link information.}
 
-\item{parameter}{a character value of parameter term name.
+\item{parameter}{A character value of parameter term name.
 The term name is used as key to link information.}
 }
 \value{

--- a/man/tlf_ae_listing.Rd
+++ b/man/tlf_ae_listing.Rd
@@ -16,11 +16,11 @@ tlf_ae_listing(
 )
 }
 \arguments{
-\item{outdata}{a outdata list created from \code{prepare_ae_listing}}
+\item{outdata}{A outdata list created by \code{\link[=prepare_ae_listing]{prepare_ae_listing()}}.}
 
-\item{footnotes}{a character vector of table footnotes}
+\item{footnotes}{A character vector of table footnotes.}
 
-\item{source}{a character value of the data source}
+\item{source}{A character value of the data source.}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -31,9 +31,9 @@ displayed e.g. c(9,20,40).}
 
 \item{orientation}{Orientation in 'portrait' or 'landscape'.}
 
-\item{path_outdata}{a character string of the outdata path}
+\item{path_outdata}{A character string of the outdata path.}
 
-\item{path_outtable}{a character string of the outtable path}
+\item{path_outtable}{A character string of the outtable path.}
 }
 \value{
 To be added.

--- a/man/tlf_ae_specific.Rd
+++ b/man/tlf_ae_specific.Rd
@@ -6,7 +6,7 @@
 \usage{
 tlf_ae_specific(
   outdata,
-  medra_version,
+  meddra_version,
   source,
   col_rel_width = NULL,
   text_font_size = 9,
@@ -18,11 +18,12 @@ tlf_ae_specific(
 )
 }
 \arguments{
-\item{outdata}{a outdata list created from \code{prepare_ae_specific}}
+\item{outdata}{A outdata list created from \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
-\item{medra_version}{a character value of the MedDRA Version for this dataset}
+\item{meddra_version}{A character value of the MedDRA version
+for this dataset.}
 
-\item{source}{a character value of the data source}
+\item{source}{A character value of the data source.}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -33,13 +34,13 @@ displayed e.g. c(9,20,40).}
 
 \item{orientation}{Orientation in 'portrait' or 'landscape'.}
 
-\item{footnotes}{a character vector of table footnotes}
+\item{footnotes}{A character vector of table footnotes.}
 
-\item{title}{a character vector of table titles}
+\item{title}{A character vector of table titles.}
 
-\item{path_outdata}{a character string of the outdata path}
+\item{path_outdata}{A character string of the outdata path.}
 
-\item{path_outtable}{a character string of the outtable path}
+\item{path_outtable}{A character string of the outtable path.}
 }
 \value{
 To be added.
@@ -59,7 +60,7 @@ meta |>
   format_ae_specific() |>
   tlf_ae_specific(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    medra_version = "24.0",
+    meddra_version = "24.0",
     path_outdata = tempfile(fileext = ".Rdata"),
     path_outtable = tempfile(fileext = ".rtf")
   )

--- a/man/tlf_ae_summary.Rd
+++ b/man/tlf_ae_summary.Rd
@@ -16,9 +16,9 @@ tlf_ae_summary(
 )
 }
 \arguments{
-\item{outdata}{a outdata list created from \code{prepare_ae_specific}}
+\item{outdata}{A outdata list created from \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
-\item{source}{a character value of the data source}
+\item{source}{A character value of the data source.}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -29,11 +29,11 @@ displayed e.g. c(9,20,40).}
 
 \item{orientation}{Orientation in 'portrait' or 'landscape'.}
 
-\item{footnotes}{a character vector of table footnotes}
+\item{footnotes}{A character vector of table footnotes.}
 
-\item{path_outdata}{a character string of the outdata path}
+\item{path_outdata}{A character string of the outdata path.}
 
-\item{path_outtable}{a character string of the outtable path}
+\item{path_outtable}{A character string of the outtable path.}
 }
 \value{
 To be added.

--- a/tests/testthat/test-independent-testing-tlf_ae_specific.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_specific.R
@@ -15,7 +15,7 @@ outdata <- prepare_ae_specific(meta,
 #   tbl <- outdata |>
 #     format_ae_specific() |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -31,7 +31,7 @@ outdata <- prepare_ae_specific(meta,
 #   tbl <- outdata |>
 #     format_ae_specific(display = c("n", "prop")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -47,7 +47,7 @@ outdata <- prepare_ae_specific(meta,
 #   tbl <- outdata |>
 #     format_ae_specific(display = c("n")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -65,7 +65,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_events() |>
 #     format_ae_specific(display = c("events", "n", "prop", "total")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -82,7 +82,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_events() |>
 #     format_ae_specific(display = c("events", "n", "prop")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -101,7 +101,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_duration(duration_var = "ADURN") |>
 #     format_ae_specific(display = c("events", "dur", "n", "prop")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -119,7 +119,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_duration(duration_var = "ADURN") |>
 #     format_ae_specific(display = c("events", "dur", "n", "prop", "total")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -136,7 +136,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_events() |>
 #     format_ae_specific(display = c("events", "n", "prop", "total")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -153,7 +153,7 @@ outdata <- prepare_ae_specific(meta,
 #     extend_ae_specific_events() |>
 #     format_ae_specific(display = c("events", "n", "prop")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -175,7 +175,7 @@ test_that("rtf output: events, dur, n, and prop w/o total", {
       mock = TRUE
     ) |>
     tlf_ae_specific(
-      medra_version = "24.0",
+      meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
       path_outdata = path_rdata,
       path_outtable = path_rtf
@@ -196,7 +196,7 @@ test_that("rtf output: events, dur, n, and prop w/ total", {
       mock = TRUE
     ) |>
     tlf_ae_specific(
-      medra_version = "24.0",
+      meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
       path_outdata = path_rdata,
       path_outtable = path_rtf
@@ -219,7 +219,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/o total", {
       "diff", "diff_p", "diff_ci"
     ), mock = TRUE) |>
     tlf_ae_specific(
-      medra_version = "24.0",
+      meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
       path_outdata = path_rdata,
       path_outtable = path_rtf
@@ -241,7 +241,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/ total", {
       "diff", "diff_p", "diff_ci"
     ), mock = TRUE) |>
     tlf_ae_specific(
-      medra_version = "24.0",
+      meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
       path_outdata = path_rdata,
       path_outtable = path_rtf
@@ -260,7 +260,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/ total", {
 #     format_ae_specific(display = c("n", "prop", "total",
 #       "diff", "diff_p", "diff_ci")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -278,7 +278,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/ total", {
 #     format_ae_specific(display = c("n", "prop", "total",
 #       "diff", "diff_p", "diff_ci")) |>
 #     tlf_ae_specific(
-#       medra_version = "24.0",
+#       meddra_version = "24.0",
 #       source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #       path_outdata =  path_rdata,
 #       path_outtable =  path_rtf
@@ -296,7 +296,7 @@ test_that("relative width 'works'", {
       tbl <- outdata |>
         format_ae_specific(display = c("n", "prop"), mock = TRUE) |>
         tlf_ae_specific(
-          medra_version = "24.0",
+          meddra_version = "24.0",
           source = "Source:  [CDISCpilot: adam-adsl; adae]",
           path_outdata = path_rdata,
           path_outtable = path_rtf,
@@ -311,7 +311,7 @@ test_that("relative width 'works'", {
       tbl <- outdata |>
         format_ae_specific(display = c("n", "prop"), mock = TRUE) |>
         tlf_ae_specific(
-          medra_version = "24.0",
+          meddra_version = "24.0",
           source = "Source:  [CDISCpilot: adam-adsl; adae]",
           path_outdata = path_rdata,
           path_outtable = path_rtf,

--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -183,7 +183,7 @@ By using `tlf_ae_specific`, we can transfer the output from `format_ae_specific`
 outdata |>
   format_ae_specific() |>
   tlf_ae_specific(
-    medra_version = "24.0",
+    meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
     path_outtable = "outtable/ae0specific1.rtf"
   )
@@ -199,7 +199,7 @@ The `tlf_ae_specific` function also provide some commonly used argument to custo
 outdata |>
   format_ae_specific() |>
   tlf_ae_specific(
-    medra_version = "24.0",
+    meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
@@ -218,7 +218,7 @@ We can also generate the mock table
 outdata |>
   format_ae_specific(mock = TRUE) |>
   tlf_ae_specific(
-    medra_version = "24.0",
+    meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
     path_outtable = "outtable/mock_ae0specific1.rtf"
   )


### PR DESCRIPTION
This PR

- Renames the argument `medra_version` to `meddra_version`. This is because I believe MedDRA is the correct spelling and it should not be abbreviated in any case.
- Uses sentence case for the remaining `@param` values that have not been fixed before.