### PR TITLE
Fix vignette rendering issues

### DIFF
--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -45,7 +45,7 @@ There are three optional functions to extend AE specification analysis.
 An example output:
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
-knitr::include_graphics("rtf/ae0specific1.rtf")
+knitr::include_graphics("pdf/ae0specific1.pdf")
 ```
 
 ## Example data

--- a/vignettes/metalite-ae.Rmd
+++ b/vignettes/metalite-ae.Rmd
@@ -33,16 +33,16 @@ including:
 
 <details>
 <summary>AE summary.</summary>
-<img src="https://merck.github.io/metalite.ae/articles/fig/ae0summary.png">
+<img src="https://merck.github.io/metalite.ae/articles/fig/ae0summary.png" width="100%">
 </details>
 <details>
 <summary>
 Specific AE analysis.</summary>
-<img src="https://merck.github.io/metalite.ae/articles/fig/ae0specific.png">
+<img src="https://merck.github.io/metalite.ae/articles/fig/ae0specific.png" width="100%">
 </details>
 <details>
 <summary>AE listing.</summary>
-<img src="https://merck.github.io/metalite.ae/articles/fig/ae0listing.png">
+<img src="https://merck.github.io/metalite.ae/articles/fig/ae0listing.png" width="100%">
 </details>
 
 The R package simplifies the workflow to create production-ready


### PR DESCRIPTION
This PR fixes two vignette rendering issues:

1. In `ae-specific.Rmd`, the RTF output was included where PDF should be included.
1. In `metalite-ae.Rmd`, the images under the `<details>` elements should have a width attribute when not rendered under pkgdown.