### PR TITLE
Add Linguist rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rtf linguist-generated


### PR DESCRIPTION
This PR adds a rule to `.gitattributes` to mark all `.rtf` files as "generated" for GitHub Linguist so the repo languages statistics is correct (currently, RTF ranks the top by number of lines).

GitHub Linguist references: [[1](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)] and [[2](https://github.com/github/linguist/blob/master/docs/overrides.md)].