### PR TITLE
Warning fix for format_ae_specific.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# metalite.ae 0.1.2
+
+- Updated `format_ae_specific` to avoid warning when no comparison variables are
+requested.
+
 # metalite.ae 0.1.1
 
 - Updated the `DESCRIPTION` file to reformat the reference.

--- a/R/format_ae_specific.R
+++ b/R/format_ae_specific.R
@@ -193,23 +193,25 @@ format_ae_specific <- function(outdata,
     ncol = n_group, byrow = TRUE
   ))]
 
-  # Arrange Between Group information
+  # Arrange group comparison information (diff, diff_ci, diff_p).
   between_var <- names(tbl)[names(tbl) %in% c("diff", "diff_ci", "diff_p")]
-  between_tbl <- tbl[between_var]
-  n_between <- length(between_tbl)
-  n_group_btw <- n_group - 1 - display_total # Always groups - 1 - total col
 
-  names(between_tbl) <- NULL
-  between_tbl <- do.call(cbind, between_tbl)
-  between_tbl <- between_tbl[, as.vector(matrix(1:(n_group_btw * n_between),
-    ncol = n_group_btw, byrow = TRUE
-  ))]
-
-  # Create Results
-  if (is.null(between_tbl)) {
-    res <- within_tbl
+  ## If there are any comparison variables selected, order their columns appropriately.
+  res <- if (length(between_var) != 0) {
+    between_tbl <- tbl[between_var]
+    n_between <- length(between_tbl)
+    # Number of comparison columns is always: treatment groups - 1 - total column (1 or 0).
+    n_group_btw <- n_group - 1 - display_total
+    names(between_tbl) <- NULL
+    # Bind all the comparison columns together.
+    between_tbl <- do.call(cbind, between_tbl)
+    # Reorder the comparison columns.
+    between_tbl <- between_tbl[, as.vector(matrix(1:(n_group_btw * n_between),
+      ncol = n_group_btw, byrow = TRUE
+    ))]
+    data.frame(within_tbl, between_tbl)
   } else {
-    res <- data.frame(within_tbl, between_tbl)
+    within_tbl
   }
 
   # Transfer to Mock

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -60,10 +60,10 @@ tlf_ae_summary <- function(outdata,
   # Define title
   if (is.null(title)) {
     title <- collect_title(outdata$meta,
-                           outdata$population,
-                           outdata$observation,
-                           parameters[1],
-                           analysis = "ae_summary"
+      outdata$population,
+      outdata$observation,
+      parameters[1],
+      analysis = "ae_summary"
     )
   }
 


### PR DESCRIPTION
- Refactor to protect against warning in format_ae_specific.
- Update news to reflect fix.

Could not reproduce warning we saw in the meeting, so I could not write a test for it. @wangben718, can you pull this down and see if it fixes your warning? The code in question should no longer be run in the case of users not requesting comparative statistics. 