### PR TITLE
Use "an" outdata object

### DIFF
--- a/R/extend_ae_specific.R
+++ b/R/extend_ae_specific.R
@@ -18,7 +18,7 @@
 
 #' Add inference information for AE specific analysis
 #'
-#' @param outdata A `outdata` object created by [prepare_ae_specific()].
+#' @param outdata An `outdata` object created by [prepare_ae_specific()].
 #' @param ci A numeric value for the percentile of confidence interval.
 #'
 #' @return A list of analysis raw datasets.
@@ -94,7 +94,7 @@ extend_ae_specific_inference <- function(outdata, ci = 0.95) {
 
 #' Add average duration information for AE specific analysis
 #'
-#' @param outdata A `outdata` object created by [prepare_ae_specific()].
+#' @param outdata An `outdata` object created by [prepare_ae_specific()].
 #' @param duration_var A character value of variable name for AE duration.
 #' @param duration_unit A character value of AE duration unit.
 #'
@@ -225,7 +225,7 @@ extend_ae_specific_duration <- function(outdata,
 
 #' Add average number of events information for AE specific analysis
 #'
-#' @param outdata A `outdata` object created by [prepare_ae_specific()].
+#' @param outdata An `outdata` object created by [prepare_ae_specific()].
 #'
 #' @return A list of analysis raw datasets.
 #'

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -18,7 +18,7 @@
 
 #' Specific adverse events table
 #'
-#' @param outdata A outdata list created by [prepare_ae_listing()].
+#' @param outdata An `outdata` object created by [prepare_ae_listing()].
 #' @param footnotes A character vector of table footnotes.
 #' @param source A character value of the data source.
 #' @inheritParams r2rtf::rtf_page

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -18,7 +18,7 @@
 
 #' Specific adverse events table
 #'
-#' @param outdata A outdata list created from [prepare_ae_specific()].
+#' @param outdata An `outdata` object created by [prepare_ae_specific()].
 #' @param meddra_version A character value of the MedDRA version
 #'   for this dataset.
 #' @param source A character value of the data source.

--- a/man/extend_ae_specific_duration.Rd
+++ b/man/extend_ae_specific_duration.Rd
@@ -7,7 +7,7 @@
 extend_ae_specific_duration(outdata, duration_var, duration_unit = "Day")
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{duration_var}{A character value of variable name for AE duration.}
 

--- a/man/extend_ae_specific_events.Rd
+++ b/man/extend_ae_specific_events.Rd
@@ -7,7 +7,7 @@
 extend_ae_specific_events(outdata)
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 }
 \value{
 A list of analysis raw datasets.

--- a/man/extend_ae_specific_inference.Rd
+++ b/man/extend_ae_specific_inference.Rd
@@ -7,7 +7,7 @@
 extend_ae_specific_inference(outdata, ci = 0.95)
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{ci}{A numeric value for the percentile of confidence interval.}
 }

--- a/man/format_ae_specific.Rd
+++ b/man/format_ae_specific.Rd
@@ -16,7 +16,7 @@ format_ae_specific(
 )
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{display}{A character vector of measurement to be displayed:
 \itemize{

--- a/man/format_ae_summary.Rd
+++ b/man/format_ae_summary.Rd
@@ -16,7 +16,7 @@ format_ae_summary(
 )
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{display}{A character vector of measurement to be displayed:
 \itemize{

--- a/man/tlf_ae_listing.Rd
+++ b/man/tlf_ae_listing.Rd
@@ -16,7 +16,7 @@ tlf_ae_listing(
 )
 }
 \arguments{
-\item{outdata}{A outdata list created by \code{\link[=prepare_ae_listing]{prepare_ae_listing()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_listing]{prepare_ae_listing()}}.}
 
 \item{footnotes}{A character vector of table footnotes.}
 

--- a/man/tlf_ae_specific.Rd
+++ b/man/tlf_ae_specific.Rd
@@ -18,7 +18,7 @@ tlf_ae_specific(
 )
 }
 \arguments{
-\item{outdata}{A outdata list created from \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{meddra_version}{A character value of the MedDRA version
 for this dataset.}

--- a/man/tlf_ae_summary.Rd
+++ b/man/tlf_ae_summary.Rd
@@ -17,7 +17,7 @@ tlf_ae_summary(
 )
 }
 \arguments{
-\item{outdata}{A outdata list created from \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{source}{A character value of the data source.}
 


### PR DESCRIPTION
This PR fixes the documentation where in some cases "a outdata object" was used while it should be "an outdata object".