### PR TITLE
Update r4csr chapter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ including:
 
 The R package simplifies the workflow to create production-ready
 tables, listings, and figures discussed in the
-[AE summary chapter](https://r4csr.org/aesummary.html) and the
-[specific AE chapter](https://r4csr.org/specific-ae.html) of the
+[AE summary chapter](https://r4csr.org/tlf-ae-summary.html) and the
+[specific AE chapter](https://r4csr.org/tlf-ae-specific.html) of the
 _R for Clinical Study Reports and Submission_ book with full traceability.
 
 The R package is created using the [metalite](https://merck.github.io/metalite/)

--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -25,7 +25,7 @@ library(metalite.ae)
 
 The purpose of this tutorial is to create production ready AE specification analyses
 by extending examples shown in the
-[specific AE chapter](https://r4csr.org/specific-ae.html)
+[specific AE chapter](https://r4csr.org/tlf-ae-specific.html)
 of the _R for Clinical Study Reports and Submission_ book.
 
 The AE specification analysis is to provide tables to summarize details of different types of adverse events.

--- a/vignettes/ae-summary.Rmd
+++ b/vignettes/ae-summary.Rmd
@@ -25,7 +25,7 @@ library(metalite.ae)
 
 The purpose of this tutorial is to create production ready AE summary analyses
 by extending examples shown in the
-[AE summary chapter](https://r4csr.org/aesummary.html)
+[AE summary chapter](https://r4csr.org/tlf-ae-summary.html)
 of the _R for Clinical Study Reports and Submission_ book.
 
 The AE summary analysis provides tables to summarize adverse events information.

--- a/vignettes/metalite-ae.Rmd
+++ b/vignettes/metalite-ae.Rmd
@@ -47,8 +47,8 @@ Specific AE analysis.</summary>
 
 The R package simplifies the workflow to create production-ready
 tables, listings, and figures discussed in the
-[AE summary chapter](https://r4csr.org/aesummary.html) and the
-[specific AE chapter](https://r4csr.org/specific-ae.html) of the
+[AE summary chapter](https://r4csr.org/tlf-ae-summary.html) and the
+[specific AE chapter](https://r4csr.org/tlf-ae-specific.html) of the
 _R for Clinical Study Reports and Submission_ book with full traceability.
 
 The R package is created using the [metalite](https://merck.github.io/metalite/)


### PR DESCRIPTION
This PR fixes the obsolete links to the r4csr book chapters due to its recent Quarto book migration in `README.md` and vignettes.