### PR TITLE
Format code and documentation from AE specific subgroup analysis

### DIFF
--- a/R/format_ae_specific_subgroup.R
+++ b/R/format_ae_specific_subgroup.R
@@ -22,20 +22,24 @@
 #' @param digits_prop A numeric value of number of digits for proportion value.
 #' @param digits_ci A numeric value of number of digits for confidence interval
 #' @param digits_p A numeric value of number of digits for p-value .
-#' @param digits_dur A numeric value of number of digits for average duration of AE
-#' @param digits_events A numeric value of number of digits for average of number of AE per subjects.
+#' @param digits_dur A numeric value of number of digits for
+#'   average duration of AE.
+#' @param digits_events A numeric value of number of digits for
+#'   average of number of AE per subjects.
 #' @param display A character vector of measurement to be displayed.
-#'  - `n`: number of subjects with AE.
-#'  - `prop`: proportion of subjects with AE.
-#'  - `total`: total columns
-#'  - `diff`: risk difference
-#'  - `diff_ci`: 95% confidence interval of risk difference using M&N method
-#'  - `diff_p`: p-value of risk difference using M&N method
-#'  - `dur`: average of AE duration
-#'  - `events`: average number of AE per subject
-#' @param mock A boolean value to display mock table
+#'   - `n`: Number of subjects with AE.
+#'   - `prop`: Proportion of subjects with AE.
+#'   - `total`: Total columns.
+#'   - `diff`: Risk difference.
+#'   - `diff_ci`: 95% confidence interval of risk difference using M&N method.
+#'   - `diff_p`: p-value of risk difference using M&N method.
+#'   - `dur`: Average of AE duration.
+#'   - `events`: Average number of AE per subject.
+#' @param mock Logical. Display mock table or not.
 #'
 #' @return A list of analysis raw datasets.
+#'
+#' @export
 #'
 #' @examples
 #' meta <- meta_ae_example()
@@ -47,16 +51,15 @@
 #'   display_subgroup_total = TRUE
 #' ) |>
 #'   format_ae_specific_subgroup()
-#'
-#' @export
-format_ae_specific_subgroup <- function(outdata,
-                                        display = c("n", "prop"),
-                                        digits_prop = 1,
-                                        digits_ci = 1,
-                                        digits_p = 3,
-                                        digits_dur = c(1, 1),
-                                        digits_events = c(1, 1),
-                                        mock = FALSE) {
+format_ae_specific_subgroup <- function(
+    outdata,
+    display = c("n", "prop"),
+    digits_prop = 1,
+    digits_ci = 1,
+    digits_p = 3,
+    digits_dur = c(1, 1),
+    digits_events = c(1, 1),
+    mock = FALSE) {
   if ("total" %in% display) {
     display <- display[!display %in% "total"]
     print(paste("total is not supported within Sub-Group"))
@@ -65,7 +68,7 @@ format_ae_specific_subgroup <- function(outdata,
   out_all <- outdata$out_all
 
   outlst <- list()
-  for (i in 1:length(out_all)) {
+  for (i in seq_along(out_all)) {
     tbl <- out_all[[i]] |>
       format_ae_specific(
         display = display,
@@ -95,7 +98,7 @@ format_ae_specific_subgroup <- function(outdata,
 
     i <- i + 1
 
-    if (i > 1 & i < length(outlst)) {
+    if (i > 1 && i < length(outlst)) {
       tbl <- merge(tbl, outlst[[i + 1]], by = "name", all = TRUE)
     }
   }
@@ -103,7 +106,7 @@ format_ae_specific_subgroup <- function(outdata,
   # Need order column from Total Column for Ordering properly across tables
   tbl <- tbl[order(tbl$order), ]
 
-  # If outdata$display_subgroup_total = FALSE remove that part
+  # If outdata$display_subgroup_total = FALSE, remove that part
   if (!outdata$display_subgroup_total) {
     rm_tot <- names(outlst$Total) # Columns from Total Section
     rm_tot <- rm_tot[!rm_tot %in% c("name", "order")]

--- a/R/prepare_ae_specific_subgroup.R
+++ b/R/prepare_ae_specific_subgroup.R
@@ -19,39 +19,46 @@
 #' Prepare datasets for AE specific analysis
 #'
 #' @inheritParams prepare_ae_specific
-#' @param subgroup_var A character value of subgroup variable name in observation data saved in `meta$data_observation`.
-#' @param subgroup_header A character vector for column header hierarchy. First element will be first level header and
-#' second element will be second level header.
-#' @param display_subgroup_total A logical Value to display total column for subgroup analysis.
+#' @param subgroup_var A character value of subgroup variable name in
+#'   observation data saved in `meta$data_observation`.
+#' @param subgroup_header A character vector for column header hierarchy.
+#'   The first element will be the first level header and the second element
+#'   will be second level header.
+#' @param display_subgroup_total Logical. Display total column for
+#'   subgroup analysis or not.
 #'
 #' @return A list of analysis raw datasets.
+#'
+#' @export
 #'
 #' @examples
 #' meta <- meta_ae_example()
 #' prepare_ae_specific_subgroup(meta, "apat", "wk12", "rel", subgroup_var = "SEX")$data
-#'
-#' @export
-prepare_ae_specific_subgroup <- function(meta,
-                                         population,
-                                         observation,
-                                         parameter,
-                                         subgroup_var,
-                                         subgroup_header = c(meta$population[[population]]$group, subgroup_var),
-                                         components = c("soc", "par"),
-                                         display_subgroup_total = TRUE) {
+prepare_ae_specific_subgroup <- function(
+    meta,
+    population,
+    observation,
+    parameter,
+    subgroup_var,
+    subgroup_header = c(meta$population[[population]]$group, subgroup_var),
+    components = c("soc", "par"),
+    display_subgroup_total = TRUE) {
   meta_original <- meta
 
-  meta$data_population[[subgroup_var]] <- factor(as.character(meta$data_population[[subgroup_var]]),
+  meta$data_population[[subgroup_var]] <- factor(
+    as.character(meta$data_population[[subgroup_var]]),
     levels = sort(unique(meta$data_population[[subgroup_var]]))
   )
-  meta$data_observation[[subgroup_var]] <- factor(as.character(meta$data_observation[[subgroup_var]]),
+  meta$data_observation[[subgroup_var]] <- factor(
+    as.character(meta$data_observation[[subgroup_var]]),
     levels = sort(unique(meta$data_observation[[subgroup_var]]))
   )
 
   meta$observation[[observation]]$group <- subgroup_header[1]
   meta$population[[population]]$group <- subgroup_header[1]
 
-  meta$data_observation <- collect_observation_record(meta,
+  meta$data_observation <- collect_observation_record(
+    meta,
     population = population,
     observation = observation,
     parameter = parameter,
@@ -63,27 +70,30 @@ prepare_ae_specific_subgroup <- function(meta,
   par_soc <- collect_adam_mapping(meta, parameter)$soc
 
   # Convert variable to factor
-  meta$data_observation[[par_var]] <- factor(as.character(meta$data_observation[[par_var]]),
+  meta$data_observation[[par_var]] <- factor(
+    as.character(meta$data_observation[[par_var]]),
     levels = sort(unique(meta$data_observation[[par_var]]))
   )
 
-  meta$data_observation[[par_soc]] <- factor(as.character(meta$data_observation[[par_soc]]),
+  meta$data_observation[[par_soc]] <- factor(
+    as.character(meta$data_observation[[par_soc]]),
     levels = sort(unique(meta$data_observation[[par_soc]]))
   )
 
   meta_subgroup <- metalite::meta_split(meta, subgroup_header[2])
 
-  outdata_all <- prepare_ae_specific(meta,
+  outdata_all <- prepare_ae_specific(
+    meta,
     population = population,
     observation = observation,
     parameter = parameter,
     components = components
   )
 
-  # Currently Total column analysis is supported for trt_within_sub.
+  # Currently, Total column analysis is supported for trt_within_sub.
   # Need programming for Total column for sub_within_trt.
-
-  outdata_subgroup <- lapply(meta_subgroup,
+  outdata_subgroup <- lapply(
+    meta_subgroup,
     prepare_ae_specific,
     population = population,
     observation = observation,
@@ -92,7 +102,7 @@ prepare_ae_specific_subgroup <- function(meta,
   )
 
   # Current output for subgroup analysis is supported for trt_within_sub.
-  # output of subgroup analysis needs restructing for sub_within_trt.
+  # output of subgroup analysis needs restructuring for sub_within_trt.
   out_all <- outdata_subgroup
   out_all$Total <- outdata_all
 

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -127,10 +127,7 @@ tlf_ae_specific <- function(outdata,
   )
 
   colhead_1_within <- paste(group, collapse = " | ")
-
-  colhead_2_within <- paste(rep(colhead_within, n_group),
-    collapse = " | "
-  )
+  colhead_2_within <- paste(rep(colhead_within, n_group), collapse = " | ")
 
   colborder_within <- vapply(
     X = col_tbl_within,

--- a/R/tlf_ae_specific_subgroup.R
+++ b/R/tlf_ae_specific_subgroup.R
@@ -39,16 +39,17 @@
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
-tlf_ae_specific_subgroup <- function(outdata,
-                                     meddra_version,
-                                     source,
-                                     col_rel_width = NULL,
-                                     text_font_size = 9,
-                                     orientation = "landscape",
-                                     footnotes = NULL,
-                                     title = NULL,
-                                     path_outdata = NULL,
-                                     path_outtable = NULL) {
+tlf_ae_specific_subgroup <- function(
+    outdata,
+    meddra_version,
+    source,
+    col_rel_width = NULL,
+    text_font_size = 9,
+    orientation = "landscape",
+    footnotes = NULL,
+    title = NULL,
+    path_outdata = NULL,
+    path_outtable = NULL) {
   if (is.null(footnotes)) {
     footnotes <- c(
       "Every participant is counted a single time for each applicable row and column.",
@@ -61,7 +62,8 @@ tlf_ae_specific_subgroup <- function(outdata,
     )
   }
 
-  footnotes <- vapply(footnotes, glue::glue_data,
+  footnotes <- vapply(
+    footnotes, glue::glue_data,
     .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
   )
   names(footnotes) <- NULL
@@ -70,15 +72,13 @@ tlf_ae_specific_subgroup <- function(outdata,
   tbl <- outdata$tbl
   tgroup <- outdata$group
   sgroup <- outdata$subgroup
-  if (outdata$display_subgroup_total) {
-    sgroup <- c(sgroup, "Total")
-  }
+  if (outdata$display_subgroup_total) sgroup <- c(sgroup, "Total")
   n_sgroup <- length(sgroup)
   n_tgroup <- length(outdata$group)
   n_row <- nrow(outdata$tbl)
   n_col <- ncol(outdata$tbl)
 
-  if (!is.null(col_rel_width) & !n_col == length(col_rel_width)) {
+  if (!is.null(col_rel_width) && !n_col == length(col_rel_width)) {
     stop(
       "col_rel_width must have the same length (has ",
       length(col_rel_width),
@@ -188,7 +188,9 @@ tlf_ae_specific_subgroup <- function(outdata,
     )
   }
 
-  if ((sum(rwidth_1) != sum(rwidth_2)) | (sum(rwidth_1) != sum(rwidth_3))) stop("width calculation broke, contact developer")
+  if ((sum(rwidth_1) != sum(rwidth_2)) || (sum(rwidth_1) != sum(rwidth_3))) {
+    stop("Width calculation breaks, contact developer.")
+  }
 
   # Column border
   border_top2 <- c("", rep("single", n_sgroup * n_tgroup))
@@ -248,6 +250,6 @@ tlf_ae_specific_subgroup <- function(outdata,
       )
   }
 
-  # prepare output
+  # Prepare output
   rtf_output(outdata, path_outdata, path_outtable)
 }

--- a/man/format_ae_specific_subgroup.Rd
+++ b/man/format_ae_specific_subgroup.Rd
@@ -16,18 +16,18 @@ format_ae_specific_subgroup(
 )
 }
 \arguments{
-\item{outdata}{A \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{display}{A character vector of measurement to be displayed.
 \itemize{
-\item \code{n}: number of subjects with AE.
-\item \code{prop}: proportion of subjects with AE.
-\item \code{total}: total columns
-\item \code{diff}: risk difference
-\item \code{diff_ci}: 95\% confidence interval of risk difference using M&N method
-\item \code{diff_p}: p-value of risk difference using M&N method
-\item \code{dur}: average of AE duration
-\item \code{events}: average number of AE per subject
+\item \code{n}: Number of subjects with AE.
+\item \code{prop}: Proportion of subjects with AE.
+\item \code{total}: Total columns.
+\item \code{diff}: Risk difference.
+\item \code{diff_ci}: 95\% confidence interval of risk difference using M&N method.
+\item \code{diff_p}: p-value of risk difference using M&N method.
+\item \code{dur}: Average of AE duration.
+\item \code{events}: Average number of AE per subject.
 }}
 
 \item{digits_prop}{A numeric value of number of digits for proportion value.}
@@ -36,11 +36,13 @@ format_ae_specific_subgroup(
 
 \item{digits_p}{A numeric value of number of digits for p-value .}
 
-\item{digits_dur}{A numeric value of number of digits for average duration of AE}
+\item{digits_dur}{A numeric value of number of digits for
+average duration of AE.}
 
-\item{digits_events}{A numeric value of number of digits for average of number of AE per subjects.}
+\item{digits_events}{A numeric value of number of digits for
+average of number of AE per subjects.}
 
-\item{mock}{A boolean value to display mock table}
+\item{mock}{Logical. Display mock table or not.}
 }
 \value{
 A list of analysis raw datasets.
@@ -58,5 +60,4 @@ prepare_ae_specific_subgroup(meta,
   display_subgroup_total = TRUE
 ) |>
   format_ae_specific_subgroup()
-
 }

--- a/man/prepare_ae_specific_subgroup.Rd
+++ b/man/prepare_ae_specific_subgroup.Rd
@@ -27,14 +27,17 @@ The term name is used as key to link information.}
 \item{parameter}{A character value of parameter term name.
 The term name is used as key to link information.}
 
-\item{subgroup_var}{A character value of subgroup variable name in observation data saved in \code{meta$data_observation}.}
+\item{subgroup_var}{A character value of subgroup variable name in
+observation data saved in \code{meta$data_observation}.}
 
-\item{subgroup_header}{A character vector for column header hierarchy. First element will be first level header and
-second element will be second level header.}
+\item{subgroup_header}{A character vector for column header hierarchy.
+The first element will be the first level header and the second element
+will be second level header.}
 
 \item{components}{A character vector of components name.}
 
-\item{display_subgroup_total}{A logical Value to display total column for subgroup analysis.}
+\item{display_subgroup_total}{Logical. Display total column for
+subgroup analysis or not.}
 }
 \value{
 A list of analysis raw datasets.
@@ -45,5 +48,4 @@ Prepare datasets for AE specific analysis
 \examples{
 meta <- meta_ae_example()
 prepare_ae_specific_subgroup(meta, "apat", "wk12", "rel", subgroup_var = "SEX")$data
-
 }

--- a/man/tlf_ae_specific_subgroup.Rd
+++ b/man/tlf_ae_specific_subgroup.Rd
@@ -18,7 +18,7 @@ tlf_ae_specific_subgroup(
 )
 }
 \arguments{
-\item{outdata}{A outdata list created from \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
+\item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{meddra_version}{A character value of the MedDRA version
 for this dataset.}

--- a/tests/testthat/test-independent-testing-avg_event.R
+++ b/tests/testthat/test-independent-testing-avg_event.R
@@ -40,9 +40,11 @@ test_that("if par = NULL, return the average number of events in each group (tak
   tmp <- db |>
     dplyr::count(group, par, id) |>
     dplyr::group_by(group, par) |>
-    dplyr::summarise(avg = mean(n, na.rm = TRUE),
+    dplyr::summarise(
+      avg = mean(n, na.rm = TRUE),
       se = sd(n, na.rm = TRUE) / sqrt(dplyr::n()),
-      .groups = "keep") |>
+      .groups = "keep"
+    ) |>
     tidyr::pivot_wider(id_cols = par, names_from = group, values_from = c("avg", "se"))
 
   avg <- dplyr::left_join(data.frame(par = unique(r2rtf_adae$AEDECOD)),
@@ -63,9 +65,11 @@ test_that("if par = NULL, return the average number of events in each group (tak
   # check to make sure that order of output is the same as input (par)
   expect_equal(se$par, unique(r2rtf_adae$AEDECOD))
 
-  avg1 <- list(avg = avg,
+  avg1 <- list(
+    avg = avg,
     se = se |>
-      dplyr::select(-par))
+      dplyr::select(-par)
+  )
   avg2 <- avg_event(r2rtf_adae$USUBJID, r2rtf_adae$TRTA, r2rtf_adae$AEDECOD)
 
   expect_equal(avg1, avg2)

--- a/tests/testthat/test-independent-testing-fmt_pval.R
+++ b/tests/testthat/test-independent-testing-fmt_pval.R
@@ -6,10 +6,9 @@ test_that("Test on data frame column", {
   expect_equal(fmt_pval(0.01), " 0.010")
   expect_equal(fmt_pval(0.001), " 0.001")
   expect_equal(fmt_pval(0.0001), "<0.001")
-
 })
 
-test_that("vectorization works",{
+test_that("vectorization works", {
   # Test data frame
   df <- data.frame(pval = c(0.1, 0.01, 0.001, 0.0001, 0.00001, NA))
   pvalue <- fmt_pval(df$pval)
@@ -18,7 +17,7 @@ test_that("vectorization works",{
 })
 
 
-test_that("vectorization works, expand width to 7",{
+test_that("vectorization works, expand width to 7", {
   # Test data frame
   df <- data.frame(pval = c(0.1, 0.01, 0.001, 0.0001, 0.00001, NA))
   pvalue <- fmt_pval(df$pval, width = 7)
@@ -26,7 +25,7 @@ test_that("vectorization works, expand width to 7",{
   expect_equal(pvalue, c("  0.100", "  0.010", "  0.001", "<0.001", "<0.001", NA))
 })
 
-test_that("vectorization works, change digits to 2, width to 7",{
+test_that("vectorization works, change digits to 2, width to 7", {
   # Test data frame
   df <- data.frame(pval = c(0.1, 0.021, 0.001, 0.0001, 0.00001, NA))
   pvalue <- fmt_pval(df$pval, digits = 2, width = 5)


### PR DESCRIPTION
This PR improves the code and documentation formatting for the content introduced by #150.

- Use scalar logical operators `||` and `&&` in conditional statements.
- Use `seq_along()` to replace `1:length(x)`.
- Format roxygen2 documentation following the tidyverse style guide and run `styler::style_pkg()`.
- Fix typos.