### PR TITLE
correct the way to assign levels attribute for observation dataset

### DIFF
--- a/R/prepare_ae_specific.R
+++ b/R/prepare_ae_specific.R
@@ -95,7 +95,8 @@ prepare_ae_specific <- function(meta,
 
   if (!"factor" %in% class(obs[[obs_group]])) {
     warning("In observation level data, force group variable '", obs_group, "' be a factor")
-    obs[[obs_group]] <- factor(obs[[obs_group]], levels = levels(pop[[pop_group]]))
+    obs[[obs_group]] <- factor(obs[[obs_group]])
+    levels(obs[[obs_group]]) <- levels(pop[[pop_group]])
   }
 
   # Add a total group to display total column


### PR DESCRIPTION
bug fix:

```r
forestly_adsl_mod <- forestly_adsl |>
  dplyr::mutate(
    TRT01A = ifelse(USUBJID == "01-718-1355", "", TRT01A),
    TRTA = factor(TRT01A, levels = c("Xanomeline Low Dose", "Placebo"), labels = c("Low Dose", "Placebo"))
  )
```

```r
forestly_adae_mod <- forestly_adae |>
  dplyr::filter(USUBJID != "01-718-1355")
```

```r
factor(forestly_adae_mod$TRTA, levels = forestly_adsl_mod$TRTA)
```

This approach will make `"Xanomeline Low Dose"` to `NA` since `"Low Dose"` could not be found in `forestly_adae_mod$TRTA` as input of `factor()`.

```r
forestly_adae_mod$TRTA <- factor(forestly_adae_mod$TRTA, levels(forestly_adsl_mod$TRTA))
levels(forestly_adae_mod$TRTA) <- levels(forestly_adsl_mod$TRTA)
```

This approach works well.