### PR TITLE
Remove `library()` calls from tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
+    tibble,
     tidyr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
-library(metalite)
 library(metalite.ae)
-library(r2rtf)
+
 test_check("metalite.ae")

--- a/tests/testthat/test-independent-testing-format_ae-specific-subgroup.R
+++ b/tests/testthat/test-independent-testing-format_ae-specific-subgroup.R
@@ -1,5 +1,3 @@
-library(metalite)
-library(metalite.ae)
 meta <- meta_ae_example()
 outdata <- prepare_ae_specific_subgroup(meta,
   population = "apat",

--- a/tests/testthat/test-independent-testing-n_subject.R
+++ b/tests/testthat/test-independent-testing-n_subject.R
@@ -1,6 +1,4 @@
-library(r2rtf)
-library(dplyr)
-library(tidyr)
+r2rtf_adae <- r2rtf::r2rtf_adae
 
 test_that("if group = ... is not a factor, throw errors", {
   expect_error(n_subject(r2rtf_adae$USUBJID, as.character(r2rtf_adae$TRTA)))

--- a/tests/testthat/test-independent-testing-prepare_ae_listing.R
+++ b/tests/testthat/test-independent-testing-prepare_ae_listing.R
@@ -1,7 +1,3 @@
-library(dplyr)
-library(metalite.ae)
-library(metalite)
-
 adsl <- r2rtf::r2rtf_adsl
 adsl$TRTA <- adsl$TRT01A
 adsl$TRTA <- factor(adsl$TRTA,
@@ -68,8 +64,8 @@ meta_ae_listing_example <- function() {
     meta_build()
 }
 
-listing_ae <- full_join(
-  adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl
+listing_ae <- dplyr::full_join(
+  adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl
   adae,
   by = "USUBJID",
   multiple = "all"
@@ -94,8 +90,8 @@ test_that("Checking Serious AE records at WK12", {
   rownames(prod_tbl) <- NULL
 
   listi <- listing_ae |>
-    filter(SAFFL == "Y" & AESER == "Y") |>
-    select(c("USUBJID", "ASTDY", "AEDECOD", "ADURN", "AESEV", "AESER", "AEREL", "AEOUT", "subline", "TRTA"))
+    dplyr::filter(SAFFL == "Y" & AESER == "Y") |>
+    dplyr::select(c("USUBJID", "ASTDY", "AEDECOD", "ADURN", "AESEV", "AESER", "AEREL", "AEOUT", "subline", "TRTA"))
 
   rownames(listi) <- NULL
   attr(listi$TRTA, "label") <- "TRTA"
@@ -118,8 +114,8 @@ test_that("Checking AE related records at WK12", {
 
 
   listi <- listing_ae |>
-    filter(SAFFL == "Y" & AEREL %in% c("POSSIBLE", "PROBABLE")) |>
-    select(c("USUBJID", "ASTDY", "AEDECOD", "ADURN", "AESEV", "AESER", "AEREL", "AEOUT", "subline", "TRTA"))
+    dplyr::filter(SAFFL == "Y" & AEREL %in% c("POSSIBLE", "PROBABLE")) |>
+    dplyr::select(c("USUBJID", "ASTDY", "AEDECOD", "ADURN", "AESEV", "AESER", "AEREL", "AEOUT", "subline", "TRTA"))
 
   rownames(listi) <- NULL
   attr(listi$TRTA, "label") <- "TRTA"

--- a/tests/testthat/test-independent-testing-prepare_ae_summary.R
+++ b/tests/testthat/test-independent-testing-prepare_ae_summary.R
@@ -15,18 +15,12 @@
 #   (take r2rtf::r2rtf_adsl and r2rtf::r2rtf_adae as an example).
 # - `name`: match the expectation.
 
-library(metalite.ae)
-library(metalite)
-library(dplyr)
-library(tidyr)
-library(testthat)
-
 adsl <- r2rtf::r2rtf_adsl
-adae <- r2rtf::r2rtf_adae |> mutate(TRT01A = TRTA)
+adae <- r2rtf::r2rtf_adae |> dplyr::mutate(TRT01A = TRTA)
 
 adsl |>
-  group_by(TRT01P) |>
-  summarise(n = n())
+  dplyr::group_by(TRT01P) |>
+  dplyr::summarize(n = dplyr::n())
 
 sum_par <- "any;rel;nonser;ser;ser0rel;dth;dtc0rel;disc;disc0drel;disc0ser;disc0ser0rel"
 plan <- plan(
@@ -48,7 +42,7 @@ meta <- meta_adam(
 
 plan_pilot <- plan |>
   subset(pilot) |>
-  mutate(display_total = analysis == "ae_summary")
+  dplyr::mutate(display_total = analysis == "ae_summary")
 
 meta <- meta |> define_plan(plan_pilot)
 
@@ -132,7 +126,7 @@ meta_example <- meta_example |>
 meta_example <- meta_example |> meta_build()
 
 meta_example$plan <- meta_example$plan |>
-  mutate(output_report = spec_filename(meta))
+  dplyr::mutate(output_report = spec_filename(meta))
 
 test_meta <- meta_example
 # usethis::use_data(test_meta, overwrite = TRUE)
@@ -148,24 +142,24 @@ test_that("output from prepare_ae_summary is a list", {
   expect_true("outdata" %in% class(x))
 })
 
-xx <- tibble(cbind(x$name, x$n)) |> mutate(x = row_number())
-xxp <- x$prop |> mutate(x = row_number())
+xx <- tibble::tibble(cbind(x$name, x$n)) |> dplyr::mutate(x = dplyr::row_number())
+xxp <- x$prop |> dplyr::mutate(x = dplyr::row_number())
 xxpd <- x$diff
-xxpd <- xxpd[order(as.numeric(row.names(xxpd))), ] |> mutate(x = row_number())
+xxpd <- xxpd[order(as.numeric(row.names(xxpd))), ] |> dplyr::mutate(x = dplyr::row_number())
 
 rownames(xxp) <- NULL
 rownames(xxpd) <- NULL
 
-adsl_tot <- adsl |> mutate(TRT01AN = 99) # Add total rows into calculation
+adsl_tot <- adsl |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
 adsl_tot <- rbind(adsl, adsl_tot)
 
 res_tot <- adsl_tot |>
-  group_by(TRT01AN, ITTFL) |>
-  summarise(n = n_distinct(USUBJID), .groups = "drop")
+  dplyr::group_by(TRT01AN, ITTFL) |>
+  dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
 res_tot1 <- res_tot |>
-  mutate(z = n) |>
-  select(-c(n))
+  dplyr::mutate(z = n) |>
+  dplyr::select(-c(n))
 
 test_that("Parameter matching", {
   expect_equal(x$parameter, sum_par)
@@ -181,10 +175,10 @@ test_that("reference_group matching", {
 
 test_that("Participants in population", {
   res <- res_tot |>
-    mutate(x = paste0("n_", row_number()))
+    dplyr::mutate(x = paste0("n_", dplyr::row_number()))
 
   res1 <- res |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -192,52 +186,52 @@ test_that("Participants in population", {
     )
 
   expect_equal(
-    xx |> filter(x == 1) |> select(-c("x$name", x)),
-    res1 |> select(-c(ITTFL))
+    xx |> dplyr::filter(x == 1) |> dplyr::select(-c("x$name", x)),
+    res1 |> dplyr::select(-c(ITTFL))
   )
   # Population count
   expect_equal(
-    xx |> filter(x == 1) |> select(-c("x$name", x)),
-    tibble(x$n_pop)
+    xx |> dplyr::filter(x == 1) |> dplyr::select(-c("x$name", x)),
+    tibble::tibble(x$n_pop)
   )
   # Name matches
   expect_equal(x$name[1], "Participants in population")
 })
 
 test_that("with one or more adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae2 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -245,63 +239,63 @@ test_that("with one or more adverse event count", {
     )
 
   res_prop2 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff2 <- res_prop2 |> mutate(
+  res_diff2 <- res_prop2 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 2) |> select(-c("x$name", x)), res_ae2 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 2) |> dplyr::select(-c("x$name", x)), res_ae2 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 2) |> select(-c(x)), data.frame(res_prop2) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 2) |> dplyr::select(-c(x)), data.frame(res_prop2) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 2) |> select(-c(x)), data.frame(res_diff2) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 2) |> dplyr::select(-c(x)), data.frame(res_diff2) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[2], "with one or more adverse events")
 })
 
 test_that("with one or more adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
-  res_no <- full_join(
+  res_no <- dplyr::full_join(
     res_tot1, # Merge with adsl to get percentage
     res_ae,
     by = c("TRT01AN", "ITTFL"),
     multiple = "all"
-  ) |> mutate(p = z - n)
+  ) |> dplyr::mutate(p = z - n)
 
   res_no <- res_no |>
-    mutate(pct = formatC(100 * p / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * p / z, digits = 13, format = "f", flag = "0"))
 
   res_no$pct <- as.numeric(res_no$pct)
 
   res_no <- res_no |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae3 <- res_no |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = p,
@@ -309,69 +303,69 @@ test_that("with one or more adverse event count", {
     )
 
   res_prop3 <- res_no |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff3 <- res_prop3 |> mutate(
+  res_diff3 <- res_prop3 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 3) |> select(-c("x$name", x)), res_ae3 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 3) |> dplyr::select(-c("x$name", x)), res_ae3 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 3) |> select(-c(x)), data.frame(res_prop3) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 3) |> dplyr::select(-c(x)), data.frame(res_prop3) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 3) |> select(-c(x)), data.frame(res_diff3) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 3) |> dplyr::select(-c(x)), data.frame(res_diff3) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[3], "with no adverse events")
 })
 
 test_that("with drug-related adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AEREL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AEREL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   if (!"RELATED" %in% res_ae$AEREL) {
     res_ae <- res_ae |>
-      select(TRT01AN, ITTFL) |>
-      distinct() |>
-      mutate(AEREL = "RELATED", n = 0)
+      dplyr::select(TRT01AN, ITTFL) |>
+      dplyr::distinct() |>
+      dplyr::mutate(AEREL = "RELATED", n = 0)
   }
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae4 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -379,24 +373,24 @@ test_that("with drug-related adverse event count", {
     )
 
   res_prop4 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff4 <- res_prop4 |> mutate(
+  res_diff4 <- res_prop4 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 4) |> select(-c("x$name", x)), res_ae4 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 4) |> dplyr::select(-c("x$name", x)), res_ae4 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 4) |> select(-c(x)), data.frame(res_prop4) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 4) |> dplyr::select(-c(x)), data.frame(res_prop4) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 4) |> select(-c(x)), data.frame(res_diff4) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 4) |> dplyr::select(-c(x)), data.frame(res_diff4) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[4], "with drug-related{^a} adverse events")
 })
@@ -404,39 +398,39 @@ test_that("with drug-related adverse event count", {
 
 
 test_that("non-serious adverse events count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y" & AESER != "Y" | AESER == "")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae5 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -444,76 +438,76 @@ test_that("non-serious adverse events count", {
     )
 
   res_prop5 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff5 <- res_prop5 |> mutate(
+  res_diff5 <- res_prop5 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 5) |> select(-c("x$name", x)), res_ae5 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 5) |> dplyr::select(-c("x$name", x)), res_ae5 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 5) |> select(-c(x)), data.frame(res_prop5) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 5) |> dplyr::select(-c(x)), data.frame(res_prop5) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 5) |> select(-c(x)), data.frame(res_diff5) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 5) |> dplyr::select(-c(x)), data.frame(res_diff5) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[5], "with non-serious adverse events")
 })
 
 test_that("serious adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AESER) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AESER) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AESER = "Y", t = as.integer(0))
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AESER = "Y", t = as.integer(0))
 
   res_ae <- res_ae |> subset(AESER == "Y")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AESER")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae6 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -521,78 +515,78 @@ test_that("serious adverse event count", {
     )
 
   res_prop6 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff6 <- res_prop6 |> mutate(
+  res_diff6 <- res_prop6 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 6) |> select(-c("x$name", x)), res_ae6 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 6) |> dplyr::select(-c("x$name", x)), res_ae6 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 6) |> select(-c(x)), data.frame(res_prop6) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 6) |> dplyr::select(-c(x)), data.frame(res_prop6) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 6) |> select(-c(x)), data.frame(res_diff6) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 6) |> dplyr::select(-c(x)), data.frame(res_diff6) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[6], "with serious adverse events")
 })
 
 
 test_that("serious drug-related adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AESER, AEREL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AESER, AEREL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AESER = "Y", AEREL = "RELATED", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AESER = "Y", AEREL = "RELATED", t = as.integer(0))
 
   res_ae <- res_ae |> subset(AESER == "Y" & AEREL == "RELATED")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AESER", "AEREL")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae7 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -600,78 +594,78 @@ test_that("serious drug-related adverse event count", {
     )
 
   res_prop7 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff7 <- res_prop7 |> mutate(
+  res_diff7 <- res_prop7 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 7) |> select(-c("x$name", x)), res_ae7 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 7) |> dplyr::select(-c("x$name", x)), res_ae7 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 7) |> select(-c(x)), data.frame(res_prop7) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 7) |> dplyr::select(-c(x)), data.frame(res_prop7) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 7) |> select(-c(x)), data.frame(res_diff7) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 7) |> dplyr::select(-c(x)), data.frame(res_diff7) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[7], "with serious drug-related adverse events")
 })
 
 
 test_that("death count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AESDTH) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AESDTH) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AESDTH = "Y", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AESDTH = "Y", t = as.integer(0))
 
   res_ae <- res_ae |> subset(AESDTH == "Y")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AESDTH")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae8 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -679,78 +673,78 @@ test_that("death count", {
     )
 
   res_prop8 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff8 <- res_prop8 |> mutate(
+  res_diff8 <- res_prop8 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 8) |> select(-c("x$name", x)), res_ae8 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 8) |> dplyr::select(-c("x$name", x)), res_ae8 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 8) |> select(-c(x)), data.frame(res_prop8) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 8) |> dplyr::select(-c(x)), data.frame(res_prop8) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 8) |> select(-c(x)), data.frame(res_diff8) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 8) |> dplyr::select(-c(x)), data.frame(res_diff8) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[8], "who died")
 })
 
 
 test_that("died due to drug-related adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AESDTH, AEREL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AESDTH, AEREL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AESDTH = "Y", AEREL = "RELATED", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AESDTH = "Y", AEREL = "RELATED", t = as.integer(0))
 
   res_ae <- res_ae |> subset(AESDTH == "Y" & AEREL == "RELATED")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AESDTH", "AEREL")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae9 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -758,77 +752,77 @@ test_that("died due to drug-related adverse event count", {
     )
 
   res_prop9 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff9 <- res_prop9 |> mutate(
+  res_diff9 <- res_prop9 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 9) |> select(-c("x$name", x)), res_ae9 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 9) |> dplyr::select(-c("x$name", x)), res_ae9 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 9) |> select(-c(x)), data.frame(res_prop9) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 9) |> dplyr::select(-c(x)), data.frame(res_prop9) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 9) |> select(-c(x)), data.frame(res_diff9) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 9) |> dplyr::select(-c(x)), data.frame(res_diff9) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[9], "who died due to a drug-related adverse event")
 })
 
 test_that("discontinued due to an adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AEACN) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AEACN) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AEACN = "DRUG WITHDRAWN", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AEACN = "DRUG WITHDRAWN", t = as.integer(0))
 
   res_ae <- res_ae |> subset(toupper(AEACN) == "DRUG WITHDRAWN")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AEACN")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae10 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -836,78 +830,78 @@ test_that("discontinued due to an adverse event count", {
     )
 
   res_prop10 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff10 <- res_prop10 |> mutate(
+  res_diff10 <- res_prop10 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 10) |> select(-c("x$name", x)), res_ae10 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 10) |> dplyr::select(-c("x$name", x)), res_ae10 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 10) |> select(-c(x)), data.frame(res_prop10) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 10) |> dplyr::select(-c(x)), data.frame(res_prop10) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 10) |> select(-c(x)), data.frame(res_diff10) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 10) |> dplyr::select(-c(x)), data.frame(res_diff10) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[10], "discontinued any drug due to an adverse events")
 })
 
 
 test_that("discontinued due to drug-related adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AEACN, AEREL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AEACN, AEREL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AEACN = "DRUG WITHDRAWN", AEREL = "RELATED", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AEACN = "DRUG WITHDRAWN", AEREL = "RELATED", t = as.integer(0))
 
   res_ae <- res_ae |> subset(toupper(AEACN) == "DRUG WITHDRAWN" & AEREL == "RELATED")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AEACN", "AEREL")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae11 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -915,78 +909,78 @@ test_that("discontinued due to drug-related adverse event count", {
     )
 
   res_prop11 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff11 <- res_prop11 |> mutate(
+  res_diff11 <- res_prop11 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 11) |> select(-c("x$name", x)), res_ae11 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 11) |> dplyr::select(-c("x$name", x)), res_ae11 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 11) |> select(-c(x)), data.frame(res_prop11) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 11) |> dplyr::select(-c(x)), data.frame(res_prop11) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 11) |> select(-c(x)), data.frame(res_diff11) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 11) |> dplyr::select(-c(x)), data.frame(res_diff11) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[11], "discontinued any drug due to a drug-related adverse events")
 })
 
 
 test_that("discontinued due to serious adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AEACN, AESER) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AEACN, AESER) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    ungroup() |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AEACN = "DRUG WITHDRAWN", AESER = "Y", t = as.integer(0))
+    dplyr::ungroup() |>
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AEACN = "DRUG WITHDRAWN", AESER = "Y", t = as.integer(0))
 
   res_ae <- res_ae |> subset(toupper(AEACN) == "DRUG WITHDRAWN" & AESER == "Y")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AEACN", "AESER")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae12 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -994,76 +988,76 @@ test_that("discontinued due to serious adverse event count", {
     )
 
   res_prop12 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff12 <- res_prop12 |> mutate(
+  res_diff12 <- res_prop12 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 12) |> select(-c("x$name", x)), res_ae12 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 12) |> dplyr::select(-c("x$name", x)), res_ae12 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 12) |> select(-c(x)), data.frame(res_prop12) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 12) |> dplyr::select(-c(x)), data.frame(res_prop12) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 12) |> select(-c(x)), data.frame(res_diff12) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 12) |> dplyr::select(-c(x)), data.frame(res_diff12) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[12], "discontinued any drug due to a serious adverse event")
 })
 
 test_that("discontinued due to serious drug-related adverse event count", {
-  adae_itt <- full_join(
-    adsl |> select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
+  adae_itt <- dplyr::full_join(
+    adsl |> dplyr::select(USUBJID, TRT01AN, ITTFL), # Merge with adsl to get percentage
     adae,
     by = "USUBJID",
     multiple = "all"
   ) |> subset(ITTFL == "Y" & TRTEMFL == "Y")
 
-  adae_tot <- adae_itt |> mutate(TRT01AN = 99) # Add total rows into calculation
+  adae_tot <- adae_itt |> dplyr::mutate(TRT01AN = 99) # Add total rows into calculation
   adae_tot <- rbind(adae_itt, adae_tot)
 
   res_ae <- adae_tot |>
-    group_by(TRT01AN, ITTFL, AEACN, AESER, AEREL) |>
-    summarise(n = n_distinct(USUBJID), .groups = "drop")
+    dplyr::group_by(TRT01AN, ITTFL, AEACN, AESER, AEREL) |>
+    dplyr::summarize(n = dplyr::n_distinct(USUBJID), .groups = "drop")
 
   res_ae_example <- res_ae |>
-    select(TRT01AN, ITTFL) |>
-    distinct() |>
-    mutate(AEACN = "DRUG WITHDRAWN", AESER = "Y", AEREL = "RELATED", t = as.integer(0))
+    dplyr::select(TRT01AN, ITTFL) |>
+    dplyr::distinct() |>
+    dplyr::mutate(AEACN = "DRUG WITHDRAWN", AESER = "Y", AEREL = "RELATED", t = as.integer(0))
 
   res_ae <- res_ae |> subset(toupper(AEACN) == "DRUG WITHDRAWN" & AESER == "Y" & AEREL == "RELATED")
 
-  res_ae <- left_join(res_ae_example,
+  res_ae <- dplyr::left_join(res_ae_example,
     res_ae,
     by = c("TRT01AN", "ITTFL", "AEACN", "AESER", "AEREL")
-  ) |> select(-c(t))
+  ) |> dplyr::select(-c(t))
 
   res_ae[is.na(res_ae)] <- 0
 
   res_ae <- data.frame(
-    full_join(
+    dplyr::full_join(
       res_ae, res_tot1,
       by = c("TRT01AN", "ITTFL"),
       multiple = "all"
     )
   ) |>
-    mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
+    dplyr::mutate(pct = formatC(100 * n / z, digits = 13, format = "f", flag = "0"))
 
   res_ae$pct <- as.numeric(res_ae$pct)
 
   res_ae <- res_ae |>
-    mutate(
-      x = paste0("n_", row_number()),
-      prop = paste0("prop_", row_number())
+    dplyr::mutate(
+      x = paste0("n_", dplyr::row_number()),
+      prop = paste0("prop_", dplyr::row_number())
     )
 
   res_ae13 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "x",
       values_from = n,
@@ -1071,24 +1065,24 @@ test_that("discontinued due to serious drug-related adverse event count", {
     )
 
   res_prop13 <- res_ae |>
-    pivot_wider(
+    tidyr::pivot_wider(
       id_cols = "ITTFL",
       names_from = "prop",
       values_from = pct,
       values_fill = list(pct = 0)
     )
 
-  res_diff13 <- res_prop13 |> mutate(
+  res_diff13 <- res_prop13 |> dplyr::mutate(
     diff_2 = as.numeric(prop_2) - as.numeric(prop_1),
     diff_3 = as.numeric(prop_3) - as.numeric(prop_1)
   )
 
   # n count
-  expect_equal(xx |> filter(x == 13) |> select(-c("x$name", x)), res_ae13 |> select(-c(ITTFL)))
+  expect_equal(xx |> dplyr::filter(x == 13) |> dplyr::select(-c("x$name", x)), res_ae13 |> dplyr::select(-c(ITTFL)))
   # Proportion count
-  expect_equal(xxp |> filter(x == 13) |> select(-c(x)), data.frame(res_prop13) |> select(-c(ITTFL)))
+  expect_equal(xxp |> dplyr::filter(x == 13) |> dplyr::select(-c(x)), data.frame(res_prop13) |> dplyr::select(-c(ITTFL)))
   # Diff count
-  expect_equal(xxpd |> filter(x == 13) |> select(-c(x)), data.frame(res_diff13) |> select(c(diff_2, diff_3)))
+  expect_equal(xxpd |> dplyr::filter(x == 13) |> dplyr::select(-c(x)), data.frame(res_diff13) |> dplyr::select(c(diff_2, diff_3)))
   # Name matches
   expect_equal(x$name[13], "discontinued any drug due to a serious drug-related adverse event")
 })

--- a/tests/testthat/test-independent-testing-tlf_ae_specific_subgroup.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_specific_subgroup.R
@@ -1,5 +1,5 @@
-library(metalite)
 meta <- meta_ae_example()
+
 outdata <- prepare_ae_specific_subgroup(meta,
   population = "apat",
   observation = "wk12",

--- a/tests/testthat/test-independent-testing-tlf_ae_summary.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_summary.R
@@ -1,6 +1,5 @@
-library(metalite)
-
 meta <- meta_ae_example()
+
 outdata <- prepare_ae_summary(
   meta,
   population = "apat",

--- a/tests/testthat/test-test-independent-testing-fmt_est.R
+++ b/tests/testthat/test-test-independent-testing-fmt_est.R
@@ -4,7 +4,7 @@ test_that("Test different type of Mean, SD and Digits", {
   expect_equal(" 11.00 ( 5.666)", fmt_est(10.99999, 5.6656, digits = c(2, 3)))
 
   x <- datasets::iris |>
-    summarise(mean = mean(Petal.Width), n = n(), sd = sd(Petal.Width))
+    dplyr::summarize(mean = mean(Petal.Width), n = dplyr::n(), sd = sd(Petal.Width))
 
   expect_equal("  1.20 ( 0.762)", fmt_est(x$mean, x$sd, digits = c(2, 3)))
   expect_equal("1.20 (0.762)", fmt_est(x$mean, x$sd, digits = c(2, 3), width = c(1, 2)))


### PR DESCRIPTION
Similar to https://github.com/Merck/metalite/pull/161, this PR removes `library()` calls from tests and qualifies the namespaces explicitly.