### PR TITLE
Update for CRAN resubmission

### DIFF
--- a/R/extend_ae_specific.R
+++ b/R/extend_ae_specific.R
@@ -33,16 +33,6 @@
 #'   observation = "wk12",
 #'   parameter = "rel"
 #' ) |>
-#'   extend_ae_specific_inference() |>
-#'   format_ae_specific(display = c("n", "prop", "diff", "diff_ci"))
-#' head(tbl$tbl)
-#'
-#' # use other options passed on to [metalite.ae::rate_compare_sum()]
-#' tbl <- prepare_ae_specific(meta,
-#'   population = "apat",
-#'   observation = "wk12",
-#'   parameter = "rel"
-#' ) |>
 #'   extend_ae_specific_inference(eps = 1e-6, bisection = 200) |>
 #'   format_ae_specific(display = c("n", "prop", "diff", "diff_ci"))
 #' head(tbl$tbl)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,5 @@
 ## Resubmission
 
-This is a resubmission. In this version, I have fixed the issues identified in v0.1.0:
+This is a resubmission. In this version, I have fixed the issue identified in v0.1.3:
 
-* Uncommented the previously commented code example in `prepare_ae_specific_subgroup.Rd`.
-* Updated DESCRIPTION to format the reference as authors (year) <https:...>.
+* Removed one example for `extend_ae_specific_inference()` to avoid long running time.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,12 @@
-## Resubmission
+## Resubmission v0.1.3
 
 This is a resubmission. In this version, I have fixed the issue identified in v0.1.3:
 
 * Removed one example for `extend_ae_specific_inference()` to avoid long running time.
+
+## Resubmission v0.1.0
+
+This is a resubmission. In this version, I have fixed the issues identified in v0.1.0:
+
+* Uncommented the previously commented code example in `prepare_ae_specific_subgroup.Rd`.
+* Updated DESCRIPTION to format the reference as authors (year) <https:...>.

--- a/man/extend_ae_specific_inference.Rd
+++ b/man/extend_ae_specific_inference.Rd
@@ -26,16 +26,6 @@ tbl <- prepare_ae_specific(meta,
   observation = "wk12",
   parameter = "rel"
 ) |>
-  extend_ae_specific_inference() |>
-  format_ae_specific(display = c("n", "prop", "diff", "diff_ci"))
-head(tbl$tbl)
-
-# use other options passed on to [metalite.ae::rate_compare_sum()]
-tbl <- prepare_ae_specific(meta,
-  population = "apat",
-  observation = "wk12",
-  parameter = "rel"
-) |>
   extend_ae_specific_inference(eps = 1e-6, bisection = 200) |>
   format_ae_specific(display = c("n", "prop", "diff", "diff_ci"))
 head(tbl$tbl)


### PR DESCRIPTION
This PR removes one example for `extend_ae_specific_inference()` to avoid long running time based on the CRAN's comment. Also, `cran-comments.md` has been updated for a resubmission.