### PR TITLE
Check in changes - DEVR-3489-fix-bugs-for-generating-title

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,4 +47,4 @@ Suggests:
     tidyr
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/tlf_ae_exp_adj.R
+++ b/R/tlf_ae_exp_adj.R
@@ -62,7 +62,7 @@ tlf_ae_exp_adj <- function(outdata,
 
   # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
   analysis_name <- names(outdata$meta$analysis)
-  if (!(analysis %in% analysis_name))  {
+  if (!(analysis %in% analysis_name)) {
     stop(
       "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE

--- a/R/tlf_ae_exp_adj.R
+++ b/R/tlf_ae_exp_adj.R
@@ -39,6 +39,7 @@
 #'   format_ae_exp_adj() |>
 #'   tlf_ae_exp_adj(
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+#'     analysis = "ae_exp_adj",
 #'     path_outdata = tempfile(fileext = ".Rdata"),
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
@@ -58,6 +59,15 @@ tlf_ae_exp_adj <- function(outdata,
   n_group <- length(outdata$group)
   n_row <- nrow(tbl)
   n_col <- ncol(tbl)
+
+  # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
+  analysis_name <- names(outdata$meta$analysis)
+  if (!(analysis %in% analysis_name))  {
+    stop(
+      "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
+      call. = FALSE
+    )
+  }
 
   parameters <- unlist(strsplit(outdata$parameter, ";"))
 

--- a/R/tlf_ae_exp_adj.R
+++ b/R/tlf_ae_exp_adj.R
@@ -20,6 +20,8 @@
 #'
 #' @inheritParams tlf_ae_specific
 #'
+#' @param analysis One of analysis name existing at `outdata$meta$analysis`
+#'
 #' @return RTF file and source dataset for exposure-adjusted AE summary table.
 #'
 #' @export
@@ -42,6 +44,7 @@
 #'   )
 tlf_ae_exp_adj <- function(outdata,
                            source,
+                           analysis,
                            col_rel_width = NULL,
                            text_font_size = 9,
                            orientation = "portrait",
@@ -65,7 +68,7 @@ tlf_ae_exp_adj <- function(outdata,
       outdata$population,
       outdata$observation,
       parameters[1],
-      analysis = "ae_exp_adj",
+      analysis = analysis,
       title_order = title
     )
   }

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -21,6 +21,7 @@
 #' @param outdata An `outdata` object created by [prepare_ae_listing()].
 #' @param footnotes A character vector of table footnotes.
 #' @param source A character value of the data source.
+#' @param analysis One of analysis name existing at `outdata$meta$analysis`
 #' @inheritParams r2rtf::rtf_page
 #' @inheritParams r2rtf::rtf_body
 #' @param path_outdata A character string of the outdata path.
@@ -45,6 +46,7 @@
 tlf_ae_listing <- function(outdata,
                            footnotes = NULL,
                            source = NULL,
+                           analysis,
                            col_rel_width = NULL,
                            text_font_size = 9,
                            orientation = "landscape",
@@ -52,7 +54,7 @@ tlf_ae_listing <- function(outdata,
                            path_outtable = NULL) {
   res <- outdata$tbl
 
-  mapping <- collect_adam_mapping(outdata$meta, "ae_listing")
+  mapping <- collect_adam_mapping(outdata$meta, analysis)
   var_name <- eval(mapping$var_name)
   subline <- eval(mapping$subline)
   subline_by <- eval(mapping$subline_by)
@@ -62,7 +64,7 @@ tlf_ae_listing <- function(outdata,
   col_name <- outdata$col_name
 
   # Define title
-  title <- collect_title(outdata$meta, outdata$population, outdata$observation, outdata$parameter, analysis = "ae_listing")
+  title <- collect_title(outdata$meta, outdata$population, outdata$observation, outdata$parameter, analysis = analysis)
 
   if (!nrow(res) == 0) {
     res <- as.data.frame(res)

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -40,6 +40,7 @@
 #'   tlf_ae_listing(
 #'     footnotes = "footnote1",
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+#'     analysis = "ae_listing",
 #'     path_outdata = tempfile(fileext = ".Rdata"),
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
@@ -53,6 +54,15 @@ tlf_ae_listing <- function(outdata,
                            path_outdata = NULL,
                            path_outtable = NULL) {
   res <- outdata$tbl
+
+  # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
+  analysis_name <- names(outdata$meta$analysis)
+  if (!(analysis %in% analysis_name))  {
+    stop(
+      "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
+      call. = FALSE
+    )
+  }
 
   mapping <- collect_adam_mapping(outdata$meta, analysis)
   var_name <- eval(mapping$var_name)

--- a/R/tlf_ae_listing.R
+++ b/R/tlf_ae_listing.R
@@ -57,7 +57,7 @@ tlf_ae_listing <- function(outdata,
 
   # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
   analysis_name <- names(outdata$meta$analysis)
-  if (!(analysis %in% analysis_name))  {
+  if (!(analysis %in% analysis_name)) {
     stop(
       "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -22,6 +22,7 @@
 #' @param meddra_version A character value of the MedDRA version
 #'   for this dataset.
 #' @param source A character value of the data source.
+#' @param analysis One of analysis name existing at `outdata$meta$analysis`
 #' @inheritParams r2rtf::rtf_page
 #' @inheritParams r2rtf::rtf_body
 #' @param footnotes A character vector of table footnotes.
@@ -53,6 +54,7 @@
 tlf_ae_specific <- function(outdata,
                             meddra_version,
                             source,
+                            analysis,
                             col_rel_width = NULL,
                             text_font_size = 9,
                             orientation = "portrait",
@@ -99,7 +101,7 @@ tlf_ae_specific <- function(outdata,
       outdata$population,
       outdata$observation,
       outdata$parameter,
-      analysis = "ae_specific",
+      analysis = analysis,
       title_order = title
     )
 

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -47,6 +47,7 @@
 #'   format_ae_specific() |>
 #'   tlf_ae_specific(
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+#'     analysis = "ae_specific",
 #'     meddra_version = "24.0",
 #'     path_outdata = tempfile(fileext = ".Rdata"),
 #'     path_outtable = tempfile(fileext = ".rtf")
@@ -90,6 +91,15 @@ tlf_ae_specific <- function(outdata,
       length(col_rel_width),
       ") as as `outdata$tbl` has number of columns (has ",
       n_col, ").",
+      call. = FALSE
+    )
+  }
+
+  # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
+  analysis_name <- names(outdata$meta$analysis)
+  if (!(analysis %in% analysis_name))  {
+    stop(
+      "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE
     )
   }

--- a/R/tlf_ae_specific.R
+++ b/R/tlf_ae_specific.R
@@ -97,7 +97,7 @@ tlf_ae_specific <- function(outdata,
 
   # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
   analysis_name <- names(outdata$meta$analysis)
-  if (!(analysis %in% analysis_name))  {
+  if (!(analysis %in% analysis_name)) {
     stop(
       "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE

--- a/R/tlf_ae_specific_subgroup.R
+++ b/R/tlf_ae_specific_subgroup.R
@@ -39,6 +39,7 @@
 #'   tlf_ae_specific_subgroup(
 #'     meddra_version = "24.0",
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+#'     analysis = "ae_specific",
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
 tlf_ae_specific_subgroup <- function(
@@ -88,6 +89,15 @@ tlf_ae_specific_subgroup <- function(
       length(col_rel_width),
       ") as as outdata$tbl has number of columns (has ",
       n_col, ")."
+    )
+  }
+
+  # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
+  analysis_name <- names(outdata$meta$analysis)
+  if (!(analysis %in% analysis_name))  {
+    stop(
+      "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
+      call. = FALSE
     )
   }
 

--- a/R/tlf_ae_specific_subgroup.R
+++ b/R/tlf_ae_specific_subgroup.R
@@ -94,7 +94,7 @@ tlf_ae_specific_subgroup <- function(
 
   # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
   analysis_name <- names(outdata$meta$analysis)
-  if (!(analysis %in% analysis_name))  {
+  if (!(analysis %in% analysis_name)) {
     stop(
       "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE

--- a/R/tlf_ae_specific_subgroup.R
+++ b/R/tlf_ae_specific_subgroup.R
@@ -20,6 +20,8 @@
 #'
 #' @inheritParams tlf_ae_specific
 #'
+#' @param analysis One of analysis name existing at `outdata$meta$analysis`
+#'
 #' @return RTF file and the source dataset for AE specific subgroup analysis table.
 #'
 #' @export
@@ -43,6 +45,7 @@ tlf_ae_specific_subgroup <- function(
     outdata,
     meddra_version,
     source,
+    analysis,
     col_rel_width = NULL,
     text_font_size = 9,
     orientation = "landscape",
@@ -94,7 +97,7 @@ tlf_ae_specific_subgroup <- function(
       outdata$population,
       outdata$observation,
       outdata$parameter,
-      analysis = "ae_specific"
+      analysis = analysis
     )
   }
 

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -60,7 +60,7 @@ tlf_ae_summary <- function(outdata,
 
   # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
   analysis_name <- names(outdata$meta$analysis)
-  if (!(analysis %in% analysis_name))  {
+  if (!(analysis %in% analysis_name)) {
     stop(
       "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
       call. = FALSE

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -37,6 +37,7 @@
 #'   format_ae_summary() |>
 #'   tlf_ae_summary(
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+#'     analysis = "ae_summary",
 #'     path_outdata = tempfile(fileext = ".Rdata"),
 #'     path_outtable = tempfile(fileext = ".rtf")
 #'   )
@@ -56,6 +57,15 @@ tlf_ae_summary <- function(outdata,
   n_group <- length(outdata$group)
   n_row <- nrow(tbl)
   n_col <- ncol(tbl)
+
+  # Check if the parameter analysis contains the correct analysis that should exist in "outdata$meta$analysis"
+  analysis_name <- names(outdata$meta$analysis)
+  if (!(analysis %in% analysis_name))  {
+    stop(
+      "Please provide a valid analysis that matches with what being defined in 'outdata$meta$analysis'",
+      call. = FALSE
+    )
+  }
 
   parameters <- unlist(strsplit(outdata$parameter, ";"))
 

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -20,6 +20,8 @@
 #'
 #' @inheritParams tlf_ae_specific
 #'
+#' @param analysis One of analysis name existing at `outdata$meta$analysis`
+#'
 #' @return RTF file and the source dataset for AE summary table.
 #'
 #' @export
@@ -40,6 +42,7 @@
 #'   )
 tlf_ae_summary <- function(outdata,
                            source,
+                           analysis,
                            col_rel_width = NULL,
                            text_font_size = 9,
                            orientation = "portrait",
@@ -63,7 +66,7 @@ tlf_ae_summary <- function(outdata,
       outdata$population,
       outdata$observation,
       parameters[1],
-      analysis = "ae_summary",
+      analysis = analysis,
       title_order = title
     )
   }

--- a/man/tlf_ae_exp_adj.Rd
+++ b/man/tlf_ae_exp_adj.Rd
@@ -7,6 +7,7 @@
 tlf_ae_exp_adj(
   outdata,
   source,
+  analysis,
   col_rel_width = NULL,
   text_font_size = 9,
   orientation = "portrait",
@@ -20,6 +21,8 @@ tlf_ae_exp_adj(
 \item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{source}{A character value of the data source.}
+
+\item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -58,6 +61,7 @@ outdata |>
   format_ae_exp_adj() |>
   tlf_ae_exp_adj(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_exp_adj",
     path_outdata = tempfile(fileext = ".Rdata"),
     path_outtable = tempfile(fileext = ".rtf")
   )

--- a/man/tlf_ae_listing.Rd
+++ b/man/tlf_ae_listing.Rd
@@ -8,6 +8,7 @@ tlf_ae_listing(
   outdata,
   footnotes = NULL,
   source = NULL,
+  analysis,
   col_rel_width = NULL,
   text_font_size = 9,
   orientation = "landscape",
@@ -21,6 +22,8 @@ tlf_ae_listing(
 \item{footnotes}{A character vector of table footnotes.}
 
 \item{source}{A character value of the data source.}
+
+\item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -50,6 +53,7 @@ prepare_ae_listing(meta, "ae_listing", "apat", "wk12", "ser") |>
   tlf_ae_listing(
     footnotes = "footnote1",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_listing",
     path_outdata = tempfile(fileext = ".Rdata"),
     path_outtable = tempfile(fileext = ".rtf")
   )

--- a/man/tlf_ae_specific.Rd
+++ b/man/tlf_ae_specific.Rd
@@ -8,6 +8,7 @@ tlf_ae_specific(
   outdata,
   meddra_version,
   source,
+  analysis,
   col_rel_width = NULL,
   text_font_size = 9,
   orientation = "portrait",
@@ -24,6 +25,8 @@ tlf_ae_specific(
 for this dataset.}
 
 \item{source}{A character value of the data source.}
+
+\item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -61,6 +64,7 @@ meta |>
   format_ae_specific() |>
   tlf_ae_specific(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     meddra_version = "24.0",
     path_outdata = tempfile(fileext = ".Rdata"),
     path_outtable = tempfile(fileext = ".rtf")

--- a/man/tlf_ae_specific_subgroup.Rd
+++ b/man/tlf_ae_specific_subgroup.Rd
@@ -8,6 +8,7 @@ tlf_ae_specific_subgroup(
   outdata,
   meddra_version,
   source,
+  analysis,
   col_rel_width = NULL,
   text_font_size = 9,
   orientation = "landscape",
@@ -24,6 +25,8 @@ tlf_ae_specific_subgroup(
 for this dataset.}
 
 \item{source}{A character value of the data source.}
+
+\item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -62,6 +65,7 @@ prepare_ae_specific_subgroup(meta,
   tlf_ae_specific_subgroup(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     path_outtable = tempfile(fileext = ".rtf")
   )
 }

--- a/man/tlf_ae_summary.Rd
+++ b/man/tlf_ae_summary.Rd
@@ -7,6 +7,7 @@
 tlf_ae_summary(
   outdata,
   source,
+  analysis,
   col_rel_width = NULL,
   text_font_size = 9,
   orientation = "portrait",
@@ -20,6 +21,8 @@ tlf_ae_summary(
 \item{outdata}{An \code{outdata} object created by \code{\link[=prepare_ae_specific]{prepare_ae_specific()}}.}
 
 \item{source}{A character value of the data source.}
+
+\item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
 \item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
 Default is NULL for equal column width.}
@@ -56,6 +59,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_summary",
     path_outdata = tempfile(fileext = ".Rdata"),
     path_outtable = tempfile(fileext = ".rtf")
   )

--- a/tests/testthat/test-independent-testing-empty_table.R
+++ b/tests/testthat/test-independent-testing-empty_table.R
@@ -39,6 +39,7 @@ generate_analysis_or_empty <- function(meta, outdata) {
       ) |>
       tlf_ae_specific(
         source = "Source: [CDISCpilot: adam-adsl; adae]",
+        analysis = "ae_specific",
         meddra_version = "24.0",
         path_outdata = path_rdata,
         path_outtable = path_rtf
@@ -74,6 +75,7 @@ test_that("RTF output: empty table or analysis table.", {
       ) |>
       tlf_ae_specific(
         source = "Source: [CDISCpilot: adam-adsl; adae]",
+        analysis = "ae_specific",
         meddra_version = "24.0",
         path_outdata = path_rdata,
         path_outtable = path_rtf

--- a/tests/testthat/test-independent-testing-tlf-ae-listing.R
+++ b/tests/testthat/test-independent-testing-tlf-ae-listing.R
@@ -15,6 +15,7 @@ tbl <- outdata |>
   tlf_ae_listing(
     footnotes = "footnote1",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_listing",
     path_outdata = path_rdata,
     path_outtable = path_rtf
   )

--- a/tests/testthat/test-independent-testing-tlf_ae_exp_adj.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_exp_adj.R
@@ -21,6 +21,7 @@ test_that("rtf output: n, total_exp, events, eaer, total", {
     ) |>
     tlf_ae_exp_adj(
       source = "Source: [CDISCpilot: adam-adsl]",
+      analysis = "ae_exp_adj",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )
@@ -51,6 +52,7 @@ test_that("rtf output: n, total_exp, events, eaer, total", {
     ) |>
     tlf_ae_exp_adj(
       source = "Source: [CDISCpilot: adam-adsl]",
+      analysis = "ae_exp_adj",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )

--- a/tests/testthat/test-independent-testing-tlf_ae_specific.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_specific.R
@@ -20,6 +20,7 @@ test_that("rtf output: events, dur, n, and prop w/o total", {
     tlf_ae_specific(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )
@@ -41,6 +42,7 @@ test_that("rtf output: events, dur, n, and prop w/ total", {
     tlf_ae_specific(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )
@@ -64,6 +66,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/o total", {
     tlf_ae_specific(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )
@@ -86,6 +89,7 @@ test_that("rtf output: diff, events, dur, n, and prop w/ total", {
     tlf_ae_specific(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       col_rel_width = c(5, rep(c(1, 2, 3, 3), 4), 1, 2, 3, 1, 2, 3),
       path_outdata = path_rdata,
       path_outtable = path_rtf
@@ -111,6 +115,7 @@ test_that("rtf output: events, dur, n, and prop w/ total", {
     tlf_ae_specific(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       path_outdata = path_rdata,
       path_outtable = path_rtf
     )
@@ -166,6 +171,7 @@ test_that("relative width 'works'", {
         tlf_ae_specific(
           meddra_version = "24.0",
           source = "Source:  [CDISCpilot: adam-adsl; adae]",
+          analysis = "ae_specific",
           path_outdata = path_rdata,
           path_outtable = path_rtf,
           col_rel_width = c(rep(1, 8))
@@ -181,6 +187,7 @@ test_that("relative width 'works'", {
         tlf_ae_specific(
           meddra_version = "24.0",
           source = "Source:  [CDISCpilot: adam-adsl; adae]",
+          analysis = "ae_specific",
           path_outdata = path_rdata,
           path_outtable = path_rtf,
           col_rel_width = c(rep(1, 7))

--- a/tests/testthat/test-independent-testing-tlf_ae_specific_subgroup.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_specific_subgroup.R
@@ -18,6 +18,7 @@ test_that("rtf output: n, and prop w/o total", {
     tlf_ae_specific_subgroup(
       meddra_version = "24.0",
       source = "Source:  [CDISCpilot: adam-adsl; adae]",
+      analysis = "ae_specific",
       # path_outdata = path_rdata,
       path_outtable = path_rtf
     )

--- a/tests/testthat/test-independent-testing-tlf_ae_summary.R
+++ b/tests/testthat/test-independent-testing-tlf_ae_summary.R
@@ -14,6 +14,7 @@ tbl <- outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_summary",
     path_outtable = path_rtf,
     path_outdata = path_rdata
   )

--- a/vignettes/ae-listing.Rmd
+++ b/vignettes/ae-listing.Rmd
@@ -101,7 +101,7 @@ tbl |> tlf_ae_listing(
   footnotes = footnote,
   orientation = "portrait",
   source = "Source:  [CDISCpilot: adam-adsl; adae]",
-  analysis = "ae_listing",  # Provide analysis type defined in meta$analysis
+  analysis = "ae_listing", # Provide analysis type defined in meta$analysis
   path_outtable = "rtf/ae0listing0ser0wk12.rtf",
   path_outdata = NULL
 )

--- a/vignettes/ae-listing.Rmd
+++ b/vignettes/ae-listing.Rmd
@@ -101,7 +101,7 @@ tbl |> tlf_ae_listing(
   footnotes = footnote,
   orientation = "portrait",
   source = "Source:  [CDISCpilot: adam-adsl; adae]",
-  analysis = "ae_listing",
+  analysis = "ae_listing",  # Provide analysis type defined in meta$analysis
   path_outtable = "rtf/ae0listing0ser0wk12.rtf",
   path_outdata = NULL
 )

--- a/vignettes/ae-listing.Rmd
+++ b/vignettes/ae-listing.Rmd
@@ -101,6 +101,7 @@ tbl |> tlf_ae_listing(
   footnotes = footnote,
   orientation = "portrait",
   source = "Source:  [CDISCpilot: adam-adsl; adae]",
+  analysis = "ae_listing",
   path_outtable = "rtf/ae0listing0ser0wk12.rtf",
   path_outdata = NULL
 )

--- a/vignettes/ae-specific-subgroup.Rmd
+++ b/vignettes/ae-specific-subgroup.Rmd
@@ -161,7 +161,7 @@ outdata |>
   tlf_ae_specific_subgroup(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",  # Provide analysis type defined in meta$analysis
+    analysis = "ae_specific", # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0specific0sub0gender1.rtf"
   )
 ```

--- a/vignettes/ae-specific-subgroup.Rmd
+++ b/vignettes/ae-specific-subgroup.Rmd
@@ -161,6 +161,7 @@ outdata |>
   tlf_ae_specific_subgroup(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     path_outtable = "rtf/ae0specific0sub0gender1.rtf"
   )
 ```

--- a/vignettes/ae-specific-subgroup.Rmd
+++ b/vignettes/ae-specific-subgroup.Rmd
@@ -161,7 +161,7 @@ outdata |>
   tlf_ae_specific_subgroup(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",
+    analysis = "ae_specific",  # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0specific0sub0gender1.rtf"
   )
 ```

--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -255,7 +255,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
+    analysis = "ae_specific", # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0specific1.rtf"
   )
 ```
@@ -273,7 +273,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
+    analysis = "ae_specific", # Provide analysis type defined in meta$analysis
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -293,7 +293,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
+    analysis = "ae_specific", # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/mock_ae0specific1.rtf"
   )
 ```

--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -255,6 +255,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     path_outtable = "rtf/ae0specific1.rtf"
   )
 ```
@@ -272,6 +273,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -291,6 +293,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_specific",
     path_outtable = "rtf/mock_ae0specific1.rtf"
   )
 ```

--- a/vignettes/ae-specific.Rmd
+++ b/vignettes/ae-specific.Rmd
@@ -255,7 +255,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",
+    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0specific1.rtf"
   )
 ```
@@ -273,7 +273,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",
+    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -293,7 +293,7 @@ outdata |>
   tlf_ae_specific(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_specific",
+    analysis = "ae_specific",   # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/mock_ae0specific1.rtf"
   )
 ```

--- a/vignettes/ae-summary.Rmd
+++ b/vignettes/ae-summary.Rmd
@@ -187,7 +187,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",  # Provide analysis type defined in meta$analysis
+    analysis = "ae_summary", # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0summary1.rtf"
   )
 ```
@@ -203,7 +203,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",  # Provide analysis type defined in meta$analysis
+    analysis = "ae_summary", # Provide analysis type defined in meta$analysis
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -230,7 +230,7 @@ outdata |>
   format_ae_summary(mock = TRUE) |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",   # Provide analysis type defined in meta$analysis
+    analysis = "ae_summary", # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/mock_ae0summary1.rtf"
   )
 ```

--- a/vignettes/ae-summary.Rmd
+++ b/vignettes/ae-summary.Rmd
@@ -187,7 +187,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",
+    analysis = "ae_summary",  # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/ae0summary1.rtf"
   )
 ```
@@ -203,7 +203,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",
+    analysis = "ae_summary",  # Provide analysis type defined in meta$analysis
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -230,7 +230,7 @@ outdata |>
   format_ae_summary(mock = TRUE) |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
-    analysis = "ae_summary",
+    analysis = "ae_summary",   # Provide analysis type defined in meta$analysis
     path_outtable = "rtf/mock_ae0summary1.rtf"
   )
 ```

--- a/vignettes/ae-summary.Rmd
+++ b/vignettes/ae-summary.Rmd
@@ -187,6 +187,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_summary",
     path_outtable = "rtf/ae0summary1.rtf"
   )
 ```
@@ -202,6 +203,7 @@ outdata |>
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_summary",
     col_rel_width = c(6, rep(1, 8)),
     text_font_size = 8,
     orientation = "landscape",
@@ -228,6 +230,7 @@ outdata |>
   format_ae_summary(mock = TRUE) |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]",
+    analysis = "ae_summary",
     path_outtable = "rtf/mock_ae0summary1.rtf"
   )
 ```

--- a/vignettes/metalite-ae.Rmd
+++ b/vignettes/metalite-ae.Rmd
@@ -89,6 +89,7 @@ meta_ae_example() |> # Example AE data created using metalite
   format_ae_summary() |>
   tlf_ae_summary(
     source = "Source:  [CDISCpilot: adam-adsl; adae]", # Define data source
+    analysis = "ae_specific", # Provide analysis type defined in meta$analysis
     path_outtable = "ae0summary.rtf" # Define output
   )
 ```


### PR DESCRIPTION
Updates made to add an argument in each of tlf_* functions for allowing the user to claim which analysis name is using; corresponding changes were also made testthat programs and vignettes program which called the tbl_* function.  With this change, the argument referring an analysis is a requirement parameter of all tlf_* function.