### PR TITLE
Remove unused arguments and fix warnings in `gt_ae_summary()`

### DIFF
--- a/R/gt_ae_summary.R
+++ b/R/gt_ae_summary.R
@@ -118,13 +118,8 @@
 gt_ae_summary <- function(outdata,
                           source,
                           analysis,
-                          col_rel_width = NULL,
-                          text_font_size = 9,
-                          orientation = "portrait",
                           title = c("analysis", "observation", "population"),
-                          footnotes = NULL,
-                          path_outdata = NULL,
-                          path_outtable = NULL) {
+                          footnotes = NULL) {
   tbl <- outdata$tbl
   group <- outdata$group
   num_groups <- length(group)
@@ -162,7 +157,7 @@ gt_ae_summary <- function(outdata,
   # Create spanner functions list
   spanner_funs <- lapply(seq_along(group), function(i) {
     function(gt_tbl) {
-      gt_tbl |> tab_spanner(
+      gt_tbl |> gt::tab_spanner(
         label = group[i],
         columns = c(paste0("n_", i), paste0("prop_", i))
       )
@@ -174,9 +169,9 @@ gt_ae_summary <- function(outdata,
   prop_cols <- paste0("prop_", 1:num_groups)
 
   cols_label_vec <- c(
-    setNames("", name_col),
-    setNames(rep("n", num_groups), n_cols),
-    setNames(rep("(%)", num_groups), prop_cols)
+    stats::setNames("", name_col),
+    stats::setNames(rep("n", num_groups), n_cols),
+    stats::setNames(rep("(%)", num_groups), prop_cols)
   )
 
   # -------------------------
@@ -212,20 +207,20 @@ gt_ae_summary <- function(outdata,
   source <- if (!is.null(source)) gt::md(convert_caret_sup(source)) else source
 
   gt_tbl <- tbl |>
-    gt() |>
-    sub_missing(columns = 1:ncol(tbl), missing_text = "") |>
-    fmt_markdown(columns = 1) |>
-    tab_header(title = gt::md(combined_title_md)) |>
+    gt::gt() |>
+    gt::sub_missing(columns = 1:ncol(tbl), missing_text = "") |>
+    gt::fmt_markdown(columns = 1) |>
+    gt::tab_header(title = gt::md(combined_title_md)) |>
     (\(gt_tbl) Reduce(function(acc, f) f(acc), spanner_funs, init = gt_tbl))() |>
-    cols_label(!!!cols_label_vec)
+    gt::cols_label(!!!cols_label_vec)
 
   # Add footnotes and source (if present). gt::tab_source_note accepts a character vector;
   # we pass the (possibly converted) footnotes and source.
   if (!is.null(footnotes) && length(footnotes) > 0) {
-    gt_tbl <- gt_tbl |> tab_source_note(footnotes)
+    gt_tbl <- gt_tbl |> gt::tab_source_note(footnotes)
   }
   if (!is.null(source) && nzchar(source)) {
-    gt_tbl <- gt_tbl |> tab_source_note(source)
+    gt_tbl <- gt_tbl |> gt::tab_source_note(source)
   }
 
   return(gt_tbl)

--- a/R/prepare_ae_specific.R
+++ b/R/prepare_ae_specific.R
@@ -213,7 +213,7 @@ prepare_ae_specific <- function(meta,
     overall_max <- NA # or 0, depending on your preference
   } else {
     # Extract the suffix part for grouping
-    groups <- sapply(strsplit(names(counts), " "), function(x) paste(tail(x, length(par_soc)), collapse = " "))
+    groups <- sapply(strsplit(names(counts), " "), function(x) paste(utils::tail(x, length(par_soc)), collapse = " "))
 
     max_per_soc <- tapply(counts, groups, max)
     overall_max <- max(max_per_soc)

--- a/man/gt_ae_summary.Rd
+++ b/man/gt_ae_summary.Rd
@@ -8,13 +8,8 @@ gt_ae_summary(
   outdata,
   source,
   analysis,
-  col_rel_width = NULL,
-  text_font_size = 9,
-  orientation = "portrait",
   title = c("analysis", "observation", "population"),
-  footnotes = NULL,
-  path_outdata = NULL,
-  path_outtable = NULL
+  footnotes = NULL
 )
 }
 \arguments{
@@ -24,23 +19,10 @@ gt_ae_summary(
 
 \item{analysis}{One of analysis name existing at \code{outdata$meta$analysis}}
 
-\item{col_rel_width}{Column relative width in a vector e.g. c(2,1,1) refers to 2:1:1.
-Default is NULL for equal column width.}
-
-\item{text_font_size}{Text font size.  To vary text font size by column, use
-numeric vector with length of vector equal to number of columns
-displayed e.g. c(9,20,40).}
-
-\item{orientation}{Orientation in 'portrait' or 'landscape'.}
-
 \item{title}{Term "analysis", "observation"and "population") for collecting
 title from metadata or a character vector of table titles.}
 
 \item{footnotes}{A character vector of table footnotes.}
-
-\item{path_outdata}{A character string of the outdata path.}
-
-\item{path_outtable}{A character string of the outtable path.}
 }
 \value{
 RTF file and the source dataset for AE summary table.

--- a/tests/testthat/test-developer-testing-gt_ae_summary.R
+++ b/tests/testthat/test-developer-testing-gt_ae_summary.R
@@ -83,13 +83,8 @@ test_that("gt_ae_summary supports NULL source and footnotes", {
     gt_ae_summary(
       source = NULL,
       analysis = "ae_summary",
-      col_rel_width = NULL,
-      text_font_size = 9,
-      orientation = "portrait",
       title = c("analysis", "observation", "population"),
-      footnotes = NULL,
-      path_outdata = NULL,
-      path_outtable = NULL
+      footnotes = NULL
     )
 
   expect_s3_class(result, "gt_tbl")


### PR DESCRIPTION
This PR updates `gt_ae_summary()` to remove unused arguments. Also, it updates `gt_ae_summary()` and `prepare_ae_specific()` to fix warnings of CMD checks.