### PR TITLE
237 tlf ae summary ignores display statistics other than n and prop and diff column name is incorrect

### DIFF
--- a/R/format_ae_specific.R
+++ b/R/format_ae_specific.R
@@ -309,7 +309,7 @@ format_ae_specific <- function(outdata,
     # Reorder the comparison columns.
     between_tbl <- between_tbl[, as.vector(matrix(1:(n_group_btw * n_between),
       ncol = n_group_btw, byrow = TRUE
-    ))]
+    )), drop = FALSE]
     data.frame(within_tbl, between_tbl)
   } else {
     within_tbl
@@ -412,6 +412,7 @@ format_ae_specific <- function(outdata,
   }
 
   outdata$tbl <- res
+  outdata$display <- display
   outdata$extend_call <- c(outdata$extend_call, match.call())
   outdata$filter_method <- filter_method
   outdata$filter_criteria <- filter_criteria

--- a/R/prepare_ae_summary.R
+++ b/R/prepare_ae_summary.R
@@ -133,19 +133,19 @@ prepare_ae_summary <- function(meta,
   })
 
   n_pop <- res[[1]]$n_pop
-  tbl_num <- do.call(rbind, lapply(res, function(x) x$n[x$order == 100, ]))
+  tbl_num <- do.call(rbind, lapply(res, function(x) x$n[x$order == 100, , drop = FALSE]))
 
   pop_prop <- res[[1]]$prop[1, ]
-  tbl_prop <- do.call(rbind, lapply(res, function(x) x$prop[x$order == 100, ]))
+  tbl_prop <- do.call(rbind, lapply(res, function(x) x$prop[x$order == 100, , drop = FALSE]))
 
   pop_diff <- res[[1]]$diff[1, ]
-  tbl_diff <- do.call(rbind, lapply(res, function(x) x$diff[x$order == 100, ]))
+  tbl_diff <- do.call(rbind, lapply(res, function(x) x$diff[x$order == 100, , drop = FALSE]))
 
   pop_ci <- res[[1]]$ci[1, ]
-  tbl_ci <- do.call(rbind, lapply(res, function(x) x$ci[x$order == 100, ]))
+  tbl_ci <- do.call(rbind, lapply(res, function(x) x$ci[x$order == 100, , drop = FALSE]))
 
   pop_p <- res[[1]]$p[1, ]
-  tbl_p <- do.call(rbind, lapply(res, function(x) x$p[x$order == 100, ]))
+  tbl_p <- do.call(rbind, lapply(res, function(x) x$p[x$order == 100, , drop = FALSE]))
 
   pop_name <- res[[1]]$name[1]
   name <- unlist(lapply(parameters, function(x) collect_adam_mapping(meta, x)$summ_row))

--- a/R/prepare_ae_summary.R
+++ b/R/prepare_ae_summary.R
@@ -135,17 +135,11 @@ prepare_ae_summary <- function(meta,
   n_pop <- res[[1]]$n_pop
   tbl_num <- do.call(rbind, lapply(res, function(x) x$n[x$order == 100, , drop = FALSE]))
 
-  pop_prop <- res[[1]]$prop[1, ]
+  pop_prop <- res[[1]]$prop[1, , drop = FALSE]
   tbl_prop <- do.call(rbind, lapply(res, function(x) x$prop[x$order == 100, , drop = FALSE]))
 
-  pop_diff <- res[[1]]$diff[1, ]
+  pop_diff <- res[[1]]$diff[1, , drop = FALSE]
   tbl_diff <- do.call(rbind, lapply(res, function(x) x$diff[x$order == 100, , drop = FALSE]))
-
-  pop_ci <- res[[1]]$ci[1, ]
-  tbl_ci <- do.call(rbind, lapply(res, function(x) x$ci[x$order == 100, , drop = FALSE]))
-
-  pop_p <- res[[1]]$p[1, ]
-  tbl_p <- do.call(rbind, lapply(res, function(x) x$p[x$order == 100, , drop = FALSE]))
 
   pop_name <- res[[1]]$name[1]
   name <- unlist(lapply(parameters, function(x) collect_adam_mapping(meta, x)$summ_row))
@@ -155,25 +149,23 @@ prepare_ae_summary <- function(meta,
     names(res) <- parameters
 
     # Extract the values for 'with no ae' row.
-    noevnt_num <- res$any$n[3, ]
-    noevnt_prop <- res$any$prop[3, ]
-    noevnt_diff <- res$any$diff[3, ]
-    noevnt_ci <- res$any$ci[3, ]
-    noevnt_p <- res$any$p[3, ]
+    noevnt_num <- res$any$n[3, , drop = FALSE]
+    noevnt_prop <- res$any$prop[3, , drop = FALSE]
+    noevnt_diff <- res$any$diff[3, , drop = FALSE]
     noevnt_name <- res$any$name[3]
 
     # Combine records with original other parameters and sort df
     rbind1 <- function(df1, df2) {
       df1 <- rbind(df1, df2)
-      df1 <- df1[order(as.numeric(row.names(df1))), ]
+      df1 <- df1[order(as.numeric(row.names(df1))), , drop = FALSE]
       df1
     }
 
     tbl_num <- rbind1(tbl_num, noevnt_num)
     tbl_prop <- rbind1(tbl_prop, noevnt_prop)
-    tbl_diff <- rbind(tbl_diff, noevnt_diff)
-    tbl_ci <- rbind(tbl_ci, noevnt_ci)
-    tbl_p <- rbind(tbl_p, noevnt_p)
+    tbl_diff <- rbind1(tbl_diff, noevnt_diff)
+    # tbl_ci <- rbind1(tbl_ci, noevnt_ci)
+    # tbl_p <- rbind1(tbl_p, noevnt_p)
     name <- append(name, noevnt_name, 1)
 
     names(res) <- NULL

--- a/R/prepare_ae_summary.R
+++ b/R/prepare_ae_summary.R
@@ -164,8 +164,6 @@ prepare_ae_summary <- function(meta,
     tbl_num <- rbind1(tbl_num, noevnt_num)
     tbl_prop <- rbind1(tbl_prop, noevnt_prop)
     tbl_diff <- rbind1(tbl_diff, noevnt_diff)
-    # tbl_ci <- rbind1(tbl_ci, noevnt_ci)
-    # tbl_p <- rbind1(tbl_p, noevnt_p)
     name <- append(name, noevnt_name, 1)
 
     names(res) <- NULL

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -127,9 +127,13 @@ tlf_ae_summary <- function(outdata,
                            path_outdata = NULL,
                            path_outtable = NULL) {
   tbl <- outdata$tbl
+  display <- outdata$display
+  display_total <- "total" == display
   group <- outdata$group
   reference_group <- outdata$reference_group
+  group_diff <- group[seq_along(group) != reference_group & group != "Total"]
   n_group <- length(outdata$group)
+  n_group_diff <- length(group_diff)
   n_row <- nrow(tbl)
   n_col <- ncol(tbl)
 
@@ -164,24 +168,102 @@ tlf_ae_summary <- function(outdata,
 
   if (!all(outdata$n_pop == 0)) {
     # Define column header
-    colheader_n <- c(
-      paste0(" | ", paste(group, collapse = " | ")),
-      paste0(" | ", paste(rep("n | (%)", n_group), collapse = " | "))
+    col_tbl_within <- strsplit(names(tbl), "_") |>
+      unlist() |>
+      (\(list) list[list %in% c("n", "prop", "dur", "eventsavg", "eventscount")])() |>
+      unique()
+
+    colhead_within <- paste(
+      vapply(
+        X = col_tbl_within,
+        FUN.VALUE = "character",
+        FUN = switch,
+        "n" = "n",
+        "prop" = "(%)",
+        "dur" = "Mean Duration (SE)",
+        "eventsavg" = "Mean Events per Participant (SE)",
+        "eventscount" = "Number of Events"
+      ),
+      collapse = " | "
     )
 
-    # TODO: add logic for CI and p-value with multipel groups following WMA mock up table.
-    # colheader_ci <- c(paste("Difference in % vs", group[reference_group]),
-    # "Estimate (95% CI)")
+    colheader <- c(
+      paste0(" | ", paste(group, collapse = " | ")),
+      paste0(" | ", paste(rep(colhead_within, n_group), collapse = " | "))
+    )
 
-    # colheader_p <- c("", "p-value")
-    # colheader <- paste(colheader_n, colheader_ci, colheader_p, sep = " | ")
+    rel_width_group <- rep(1, length(col_tbl_within) * n_group)
+    rel_width <- c(3, rel_width_group)
 
-    colheader <- colheader_n
+    colborder_within <- vapply(
+      X = col_tbl_within,
+      FUN.VALUE = "character",
+      FUN = switch,
+      "n" = "single",
+      "prop" = "",
+      "dur" = "single",
+      "eventsavg" = "single",
+      "eventscount" = "",
+      USE.NAMES = FALSE
+    )
+
+    border_left <- c(
+      "single",
+      rep(colborder_within, n_group)
+    )
+
+    # For CI and p-value with multiple groups following WMA mock up table.
+    col_tbl_between <- strsplit(names(tbl), "_") |>
+      unlist() |>
+      (\(list) list[list %in% c("diff", "ci", "p")])() |>
+      unique()
+
+    if (length(col_tbl_between) > 0) {
+      colhead_between <- paste(
+        vapply(
+          X = col_tbl_between,
+          FUN.VALUE = "character",
+          FUN = switch,
+          "diff" = "Estimate",
+          "ci" = paste0("(", outdata$ci_level * 100, "% CI)"),
+          "p" = "p-value",
+        ),
+        collapse = " | "
+      )
+
+      if (n_group_diff == 1) {
+        colheader_ci <- paste("Difference in % vs", group[reference_group])
+      } else {
+        colheader_ci <- paste0(paste("Difference in %", group_diff, "vs", group[reference_group]), collapse = " | ")
+      }
+
+      colheader_ci <- c(
+        colheader_ci,
+        paste(rep(colhead_between, n_group_diff), collapse = " | ")
+      )
+
+      colheader <- paste(colheader, colheader_ci, sep = " | ")
+
+      rel_width_diff <- rep(1, length(col_tbl_between) * (n_group_diff))
+      rel_width <- c(rel_width, rel_width_diff)
+
+      colborder_between <- vapply(
+        X = col_tbl_between,
+        FUN.VALUE = "character",
+        FUN = switch,
+        "diff" = "single",
+        "ci" = "",
+        "p" = "single",
+        USE.NAMES = FALSE
+      )
+      border_left <- c(
+        border_left,
+        rep(colborder_between, n_group_diff)
+      )
+    }
 
     # Relative width
-    if (is.null(col_rel_width)) {
-      rel_width <- c(3, rep(1, 2 * n_group))
-    } else {
+    if (!is.null(col_rel_width)) {
       rel_width <- col_rel_width
     }
 
@@ -189,13 +271,18 @@ tlf_ae_summary <- function(outdata,
 
     rel_width1 <- c(
       rel_width[1],
-      tapply(rel_width[2:(n_group * 2 + 1)], c(rep(1:n_group, each = 2)), sum),
-      rel_width[-(1:(n_group * 2 + 1))]
+      tapply(rel_width[2:(n_group * 2 + 1)], c(rep(1:n_group, each = 2)), sum)
     )
+
+    if (length(col_tbl_between) > 0) {
+      rel_width1 <- c(
+        rel_width1,
+        tapply(rel_width_diff, c(rep(1:n_group_diff, each = length(col_tbl_between))), sum)
+      )
+    }
 
     # Column boarder
     border_top <- c("", rep("single", n_col - 1))
-    border_left <- c("single", rep(c("single", ""), n_group), rep("single", n_col - n_group * 2 - 1))
 
     # Using order number to customize row format
     text_justification <- c("l", rep("c", n_col - 1))

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -277,9 +277,11 @@ tlf_ae_summary <- function(outdata,
     if (length(col_tbl_between) > 0) {
       rel_width1 <- c(
         rel_width1,
-        tapply(rel_width[(n_group * 2 + 2):n_col],
-               c(rep(1:n_group_diff,each = length(col_tbl_between))),
-               sum)
+        tapply(
+          rel_width[(n_group * 2 + 2):n_col],
+          c(rep(1:n_group_diff, each = length(col_tbl_between))),
+          sum
+        )
       )
     }
 

--- a/R/tlf_ae_summary.R
+++ b/R/tlf_ae_summary.R
@@ -277,7 +277,9 @@ tlf_ae_summary <- function(outdata,
     if (length(col_tbl_between) > 0) {
       rel_width1 <- c(
         rel_width1,
-        tapply(rel_width_diff, c(rep(1:n_group_diff, each = length(col_tbl_between))), sum)
+        tapply(rel_width[(n_group * 2 + 2):n_col],
+               c(rep(1:n_group_diff,each = length(col_tbl_between))),
+               sum)
       )
     }
 

--- a/tests/testthat/_snaps/independent-testing-tlf_ae_summary.md
+++ b/tests/testthat/_snaps/independent-testing-tlf_ae_summary.md
@@ -3,7 +3,7 @@
     Code
       tbl
     Output
-      List of 18
+      List of 19
        $ meta           :List of 7
        $ population     : chr "apat"
        $ observation    : chr "wk12"
@@ -18,6 +18,7 @@
        $ name           : chr [1:5] "Participants in population" "with one or more adverse events" "with no adverse events" "with drug-related{^a} adverse events" ...
        $ prepare_call   : language prepare_ae_summary(meta = meta, population = "apat", observation = "wk12",      parameter = "any;rel;ser")
        $ tbl            :'data.frame':	5 obs. of  9 variables:
+       $ display        : chr [1:3] "n" "prop" "total"
        $ extend_call    :List of 1
        $ filter_method  : chr "percent"
        $ filter_criteria: num 0

--- a/vignettes/rtf/ae0summary2.rtf
+++ b/vignettes/rtf/ae0summary2.rtf
@@ -23,22 +23,28 @@
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Difference in % vs Placebo}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4000
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6000
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7000
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9000
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Estimate}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (95% CI)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3000
@@ -47,7 +53,7 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Participants in population}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 84}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
@@ -63,7 +69,7 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with one or more adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 77}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (91.7)}\cell
@@ -79,13 +85,13 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with no adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.3)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 17}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (19.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  35.7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -11.4}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-22.2, -1.0)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
@@ -95,13 +101,13 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6000
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with drug-related{\super a} adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 73}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (86.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 44}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (51.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  35.7}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (22.4, 48.0)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
@@ -111,13 +117,13 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6000
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8000
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with serious adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -11.4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-3.1,  6.5)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc


### PR DESCRIPTION
This PR implemented "diff"-realated display in `tlf_ae_summary()` and updated `prepare_ae_summary()` and `format_ae_summary()` to support robustness when the out-table contains only one "diff"-related column.