### PR TITLE
245 change the display in subgroup analysis for specific ae vigntette

### DIFF
--- a/R/format_ae_specific_subgroup.R
+++ b/R/format_ae_specific_subgroup.R
@@ -31,7 +31,8 @@
 #'   - `prop`: Proportion of subjects with adverse event.
 #'   - `total`: Total columns.
 #'   - `dur`: Average of adverse event duration.
-#'   - `events`: Average number of adverse event per subject.
+#'   - `events_avg`: Average number of adverse event per subject.
+#'   - `events_count`: Count number of adverse event per subject.
 #' @param mock Logical. Display mock table or not.
 #'
 #' @return A list of analysis raw datasets for subgroup analysis.

--- a/R/tlf_ae_specific_subgroup.R
+++ b/R/tlf_ae_specific_subgroup.R
@@ -173,7 +173,7 @@ tlf_ae_specific_subgroup <- function(
     col_tbl_within <- outdata$display
 
     col_tbl_within <- col_tbl_within |>
-      (\(list) list[list %in% c("n", "prop", "dur", "events")])() |>
+      (\(list) list[list %in% c("n", "prop", "dur", "events_avg", "events_count")])() |>
       unique()
 
     colhead_within <- paste(
@@ -184,7 +184,8 @@ tlf_ae_specific_subgroup <- function(
         "n" = "n",
         "prop" = "(%)",
         "dur" = "Mean Duration (SE)",
-        "events" = "Mean Events per Participant (SE)"
+        "events_avg" = "Mean Events per Participant (SE)",
+        "events_count" = "Number of Events"
       ),
       collapse = " | "
     )
@@ -200,7 +201,8 @@ tlf_ae_specific_subgroup <- function(
       "n" = "single",
       "prop" = "",
       "dur" = "single",
-      "events" = "single",
+      "events_avg" = "single",
+      "events_count" = "",
       USE.NAMES = FALSE
     )
 
@@ -270,14 +272,13 @@ tlf_ae_specific_subgroup <- function(
 
     # Column border
     border_top2 <- c("", rep("single", n_sgroup * n_tgroup))
-    border_top3 <- c("", rep("single", n_sgroup * n_tgroup * 2))
+    border_top3 <- c("", rep("single", n_sgroup * n_tgroup * length(col_tbl_within)))
 
     border_left2 <- c("single", rep("single", n_sgroup * n_tgroup))
     border_left3 <- c("single", colborder_within)
 
     # Using order number to customize row format
-
-    text_justification <- c("l", rep("c", n_sgroup * n_tgroup * 2))
+    text_justification <- c("l", rep("c", n_sgroup * n_tgroup * length(col_tbl_within)))
 
     if (length(outdata$components) == 2) {
       text_format <- ifelse(tbl$order %% 1000 == 0, "b", "")

--- a/man/format_ae_specific_subgroup.Rd
+++ b/man/format_ae_specific_subgroup.Rd
@@ -24,7 +24,8 @@ format_ae_specific_subgroup(
 \item \code{prop}: Proportion of subjects with adverse event.
 \item \code{total}: Total columns.
 \item \code{dur}: Average of adverse event duration.
-\item \code{events}: Average number of adverse event per subject.
+\item \code{events_avg}: Average number of adverse event per subject.
+\item \code{events_count}: Count number of adverse event per subject.
 }}
 
 \item{digits_prop}{A numeric value of number of digits for proportion value.}

--- a/vignettes/ae-specific-subgroup.Rmd
+++ b/vignettes/ae-specific-subgroup.Rmd
@@ -113,7 +113,7 @@ prepare_ae_specific_subgroup(
   subgroup_header = c("TRTA", "SEX"),
   display_subgroup_total = TRUE
 ) |>
-  format_ae_specific_subgroup(display = c("n", "prop", "diff")) |>
+  format_ae_specific_subgroup(display = c("n", "prop")) |>
   tlf_ae_specific_subgroup(
     meddra_version = "24.0",
     source = "Source:  [CDISCpilot: adam-adsl; adae]",

--- a/vignettes/rtf/ae0specific0sub0gender1.rtf
+++ b/vignettes/rtf/ae0specific0sub0gender1.rtf
@@ -87,28 +87,25 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Participants in population}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 50}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 53}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 34}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 33}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 84}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 86}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 86}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
@@ -118,38 +115,22 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 with one or more drug-related adverse events}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with one or more drug-related adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 41}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (82.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 28}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (52.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  29.2}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 32}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (94.1)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 16}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (48.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  45.6}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 73}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (86.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 44}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (51.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  35.7}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -158,29 +139,26 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 with no drug-related adverse events}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 with no drug-related adverse events}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (18.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 25}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (47.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -29.2}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (5.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 17}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (51.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -45.6}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (13.1)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 42}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (48.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 -35.7}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -192,12 +170,10 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 }\cell
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
@@ -211,409 +187,34 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Cardiac disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 4}\cell
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Cardiac disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (8.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (7.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.5}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (8.8)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (6.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   2.8}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 7}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (8.3)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (7.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   1.4}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (7.0)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Atrial fibrillation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Atrial flutter}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Atrioventricular block first degree}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Atrioventricular block second degree}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Bradycardia}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Bundle branch block right}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Cardiac failure congestive}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -627,499 +228,21 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Myocardial infarction}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.1}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Palpitations}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Sinus arrhythmia}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Atrial fibrillation}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  -3.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Sinus bradycardia}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Supraventricular extrasystoles}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Ventricular extrasystoles}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Wolff-parkinson-white syndrome}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Congenital, familial and genetic disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Ventricular septal defect}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Ear and labyrinth disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Tinnitus}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Vertigo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Eye disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -1133,563 +256,21 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Vision blurred}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Atrial flutter}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Gastrointestinal disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (12.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  10.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (9.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -3.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (9.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   4.9}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Abdominal pain}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Diarrhoea}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -9.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Dyspepsia}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Gastrooesophageal reflux disease}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Nausea}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   3.6}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Vomiting}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b General disorders and administration site conditions}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 23}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (46.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 11}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (20.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  25.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 20}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (58.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (21.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  37.6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 43}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (51.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 18}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (20.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  30.3}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site bleeding}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site dermatitis}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 (10.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.9}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site desquamation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site discolouration}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -1703,563 +284,21 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site erythema}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (20.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  17.6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (14.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  10.8}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site induration}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Atrioventricular block first degree}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site irritation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (12.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   8.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   7.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site pruritus}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (24.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  16.5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 (29.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  23.4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 22}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (26.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  19.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site reaction}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site swelling}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site urticaria}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   5.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site vesicles}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   5.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   3.6}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Application site warmth}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Asthenia}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Chills}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -0.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Fatigue}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Malaise}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -2273,428 +312,25 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Oedema}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Pain}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Atrioventricular block second degree}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Injury, poisoning and procedural complications}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Fall}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Skin laceration}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Wound}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Investigations}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (6.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -6.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -2.3}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Blood creatine phosphokinase increased}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Body temperature increased}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Electrocardiogram st segment depression}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Heart rate increased}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
@@ -2703,69 +339,22 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Heart rate irregular}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Bradycardia}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Metabolism and nutrition disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -5.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -3.5}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
@@ -2779,22 +368,19 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Decreased appetite}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Bundle branch block right}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \intbl\row\pard
 
 
@@ -2873,28 +459,1793 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Cardiac failure congestive}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Myocardial infarction}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Palpitations}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Sinus arrhythmia}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Sinus bradycardia}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Supraventricular extrasystoles}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Ventricular extrasystoles}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Wolff-parkinson-white syndrome}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Congenital, familial and genetic disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Ventricular septal defect}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Ear and labyrinth disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\intbl\row\pard
+
+
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240\landscape
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Tinnitus}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Vertigo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Eye disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Vision blurred}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Gastrointestinal disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (12.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (9.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 8}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (9.5)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.7)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Abdominal pain}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Diarrhoea}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Dyspepsia}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Gastrooesophageal reflux disease}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Nausea}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Vomiting}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b General disorders and administration site conditions}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 23}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (46.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 11}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (20.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 20}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (58.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (21.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 43}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (51.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 18}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (20.9)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site bleeding}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+
+
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240\landscape
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site dermatitis}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.8)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site desquamation}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site discolouration}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site erythema}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (20.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (14.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site induration}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site irritation}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (12.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site pruritus}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (24.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.5)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 10}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (29.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 22}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (26.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site reaction}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site swelling}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+
+
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240\landscape
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site urticaria}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (5.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site vesicles}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Application site warmth}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Asthenia}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Chills}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Fatigue}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Malaise}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Oedema}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Pain}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Injury, poisoning and procedural complications}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Fall}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Skin laceration}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Wound}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+
+
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240\landscape
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Investigations}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (6.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.7)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Blood creatine phosphokinase increased}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Body temperature increased}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Electrocardiogram st segment depression}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Heart rate increased}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Heart rate irregular}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Metabolism and nutrition disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Decreased appetite}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Food craving}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
@@ -2904,175 +2255,22 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Increased appetite}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Increased appetite}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Musculoskeletal and connective tissue disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Shoulder pain}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Nervous system disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (16.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  10.3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (11.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (6.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   5.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 12}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (14.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (5.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   8.5}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Balance disorder}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
@@ -3080,23 +2278,25 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Complex partial seizures}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Musculoskeletal and connective tissue disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
 \intbl\row\pard
 
 
@@ -3163,11 +2363,6 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -3178,164 +2373,24 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Coordination abnormal}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   2.0}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Shoulder pain}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Dizziness}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (6.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   5.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   4.8}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Headache}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.1}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Lethargy}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Paraesthesia oral}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -3349,22 +2404,19 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Somnolence}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Nervous system disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 8}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (16.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (11.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (6.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (14.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (5.8)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
@@ -3379,28 +2431,249 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Balance disorder}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Complex partial seizures}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Coordination abnormal}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Dizziness}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Headache}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Lethargy}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Paraesthesia oral}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Somnolence}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Stupor}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
@@ -3410,38 +2683,22 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Syncope}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Syncope}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   8.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.8)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.8}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -3450,93 +2707,28 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Transient ischaemic attack}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Transient ischaemic attack}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Psychiatric disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (12.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  10.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (8.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   5.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (10.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   8.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Agitation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
@@ -3547,28 +2739,20 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Anxiety}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   3.6}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Psychiatric disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (12.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (10.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.3)}\cell
 \intbl\row\pard
 
 
@@ -3635,14 +2819,6 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -3650,198 +2826,27 @@
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Confusional state}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Agitation}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -0.1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Depressed mood}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Irritability}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Restlessness}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Renal and urinary disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Enuresis}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -3855,563 +2860,245 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Reproductive system and breast disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Anxiety}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Confusional state}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Depressed mood}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Irritability}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Restlessness}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Renal and urinary disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Enuresis}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Reproductive system and breast disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Pelvic pain}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Respiratory, thoracic and mediastinal disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -3.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -2.3}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Dyspnoea}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Emphysema}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Skin and subcutaneous tissue disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 21}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (42.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 12}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (22.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  19.4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 18}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (52.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (15.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  37.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 39}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (46.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 17}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b (19.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  26.7}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Blister}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   8.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Cold sweat}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Dermatitis contact}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Erythema}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 (14.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (17.6)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   8.6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (15.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   5.0}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Hyperhidrosis}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   8.8}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (4.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   3.6}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Pruritus}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (24.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  12.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (26.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  23.4}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 21}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (25.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  16.9}\cell
-\intbl\row\pard
-
-
-{\pard\fs2\par}\page{\pard\fs2\par}
-\paperw15840\paperh12240\landscape
-
-\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
-
-{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
-
-
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Pruritus generalised}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -4425,267 +3112,21 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Rash}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (12.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   8.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (14.7)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  11.7}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (13.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   9.6}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Rash erythematous}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.4}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Rash pruritic}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Skin exfoliation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Skin irritation}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (3.8)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   6.2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.1)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   4.8}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Skin ulcer}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Urticaria}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.9}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
-\intbl\row\pard
-\trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b Vascular disorders}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Respiratory, thoracic and mediastinal disorders}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   4.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.8)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  -3.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   1.2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.3)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
@@ -4696,27 +3137,24 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Hypertension}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Dyspnoea}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   2.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
@@ -4729,24 +3167,20 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Hypotension}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (2.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   2.0}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Emphysema}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0   0.0}\cell
 \intbl\row\pard
 
 
@@ -4813,6 +3247,575 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Skin and subcutaneous tissue disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 21}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (42.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (22.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 18}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (52.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (15.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 39}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (46.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 17}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (19.8)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Blister}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (6.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Cold sweat}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Dermatitis contact}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Erythema}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (14.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (17.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (9.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (15.5)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Hyperhidrosis}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Pruritus}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 12}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (24.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (11.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (26.5)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 21}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (25.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (8.1)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Pruritus generalised}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Rash}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (12.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (14.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (13.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.5)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Rash erythematous}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Rash pruritic}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Skin exfoliation}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Skin irritation}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (7.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Skin ulcer}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Urticaria}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.9)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Vascular disorders}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (4.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (2.4)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  (1.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Hypertension}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Hypotension}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\intbl\row\pard
+
+
+{\pard\fs2\par}\page{\pard\fs2\par}
+\paperw15840\paperh12240\landscape
+
+\margl1440\margr1440\margt2880\margb1800\headery1800\footery1800
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Participants with Drug-Related Adverse Events}\line\fs24{\f0 Weeks 0 to 12}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5487
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8864
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12241
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 f}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 m}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2110
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2954
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3798
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4642
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5486
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6330
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7174
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8018
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8862
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx9706
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx10550
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx11394
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx12238
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
@@ -4824,27 +3827,20 @@
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9706
 \clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx10550
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx11394
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2110
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2954
-\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3798
-\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4642
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\qc\fs18{\f0 Orthostatic hypotension}\cell
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx12238
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Orthostatic hypotension}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   0.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.0)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -3.0}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  -1.2}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx12240


### PR DESCRIPTION
This PR updated the `display` keyword in the subgroup functions to align with the latest `format_ae_specific()`. Also, it removed "diff" from `vignettes/ae-specific-subgroup.Rmd` since it is not intended to use for the `format_ae_specific_subgroup()`.