### PR TITLE
247 source null as default for gt ae summary and gt ae specific

### DIFF
--- a/R/gt_ae_specific.R
+++ b/R/gt_ae_specific.R
@@ -170,7 +170,7 @@ gt_ae_specific <- function(outdata,
 
   if (!is.null(meddra_version)) {
     footnotes <- vapply(footnotes, glue::glue_data,
-                        .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
+      .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
     )
   }
 

--- a/R/gt_ae_specific.R
+++ b/R/gt_ae_specific.R
@@ -96,8 +96,8 @@
 #'     analysis = "ae_specific"
 #'   )
 gt_ae_specific <- function(outdata,
-                           meddra_version,
-                           source,
+                           meddra_version = NULL,
+                           source = NULL,
                            analysis,
                            footnotes = NULL,
                            title = c("analysis", "observation", "population")) {
@@ -108,9 +108,14 @@ gt_ae_specific <- function(outdata,
         "A system organ class or specific adverse event appears on this report only if",
         "its incidence in one or more of the columns meets the incidence",
         "criterion in the report title, after rounding."
-      ),
-      "Adverse event terms are from MedDRA Version {meddra_version}."
+      )
     )
+    if (!is.null(meddra_version)) {
+      footnotes <- c(
+        footnotes,
+        "Adverse event terms are from MedDRA Version {meddra_version}."
+      )
+    }
   }
 
   tbl <- outdata$tbl
@@ -163,9 +168,12 @@ gt_ae_specific <- function(outdata,
     }
   }
 
-  footnotes <- vapply(footnotes, glue::glue_data,
-    .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
-  )
+  if (!is.null(meddra_version)) {
+    footnotes <- vapply(footnotes, glue::glue_data,
+                        .x = list(meddra_version = meddra_version), FUN.VALUE = character(1)
+    )
+  }
+
   names(footnotes) <- NULL
 
   convert_caret_sup <- function(x) {

--- a/R/gt_ae_summary.R
+++ b/R/gt_ae_summary.R
@@ -116,7 +116,7 @@
 #'     source = "Source:  [CDISCpilot: adam-adsl; adae]"
 #'   )
 gt_ae_summary <- function(outdata,
-                          source,
+                          source = NULL,
                           analysis,
                           title = c("analysis", "observation", "population"),
                           footnotes = NULL) {

--- a/man/gt_ae_specific.Rd
+++ b/man/gt_ae_specific.Rd
@@ -6,8 +6,8 @@
 \usage{
 gt_ae_specific(
   outdata,
-  meddra_version,
-  source,
+  meddra_version = NULL,
+  source = NULL,
   analysis,
   footnotes = NULL,
   title = c("analysis", "observation", "population")

--- a/man/gt_ae_summary.Rd
+++ b/man/gt_ae_summary.Rd
@@ -6,7 +6,7 @@
 \usage{
 gt_ae_summary(
   outdata,
-  source,
+  source = NULL,
   analysis,
   title = c("analysis", "observation", "population"),
   footnotes = NULL


### PR DESCRIPTION
This PR updates the default `source` and `meddra_version` in `gt_ae_summary()` and `gt_ae_specific()` to `NULL`. 