### PR TITLE
fix: return MN CI for zero-event case (#210)

### DIFF
--- a/R/rate_compare.R
+++ b/R/rate_compare.R
@@ -193,7 +193,7 @@ rate_compare_sum <- function(
   eps = 1e-06,
   alpha = 0.05
 ) {
-  if (any(is.na(c(n0, n1, x0, x1))) || all(c(x0, x1) == 0)) {
+  if (any(is.na(c(n0, n1, x0, x1)))) {
     z <- data.frame(
       est = NA, z_score = NA,
       p = NA, lower = NA, upper = NA
@@ -238,16 +238,17 @@ rate_compare_sum <- function(
 
   # Start to calculate R tilter
   r0t <- 2 * p * cos(a) - l2 / (3 * l3)
+  r0t <- pmax(pmin(r0t, pmin(1, 1 - delta)), pmax(0, -delta))
   r1t <- r0t + delta
   vart <- (r1t * (1 - r1t) / n1 + r0t * (1 - r0t) / n0) * (n / (n - 1))
 
   if (is.null(strata) || length(unique(strata)) == 1) {
     r_diff <- (r1 - r0)
-    z_score <- (r_diff - delta) / sqrt(vart)
-    pval <- switch(test,
-      one.sided = ifelse(delta <= 0, 1 - pnorm(z_score), pnorm(z_score)),
-      two.sided = 1 - pchisq(z_score^2, 1)
-    )
+    z_score <- if (isTRUE(r_diff == delta) && isTRUE(vart == 0)) {
+      0
+    } else {
+      (r_diff - delta) / sqrt(vart)
+    }
   }
   if (!length(unique(strata)) == 1) {
     # Start to calculate the Chi-square
@@ -260,8 +261,17 @@ rate_compare_sum <- function(
     r0_w <- r0 * w
     var_w <- w^2 * vart
     r_diff <- (sum(r1_w) - sum(r0_w))
-    z_score <- (r_diff - delta) / sqrt(sum(var_w))
-    pval <- switch(test,
+    z_score <- if (isTRUE(r_diff == delta) && isTRUE(sum(var_w) == 0)) {
+      0
+    } else {
+      (r_diff - delta) / sqrt(sum(var_w))
+    }
+  }
+
+  pval <- if (isTRUE(z_score == 0) && all(c(x0, x1) == 0)) {
+    1
+  } else {
+    switch(test,
       one.sided = ifelse(delta <= 0, 1 - pnorm(z_score), pnorm(z_score)),
       two.sided = 1 - pchisq(z_score^2, 1)
     )
@@ -353,12 +363,17 @@ rate_compare_sum <- function(
     a <- (pi + acos(temp)) / 3
     # Start to calculate R tilter
     r0t <- 2 * p * cos(a) - l2 / (3 * l3)
+    r0t <- pmax(pmin(r0t, pmin(1, 1 - d)), pmax(0, -d))
     r1t <- r0t + d
     vart <- (r1t * (1 - r1t) / n1 + r0t * (1 - r0t) / n0) * (n / (n - 1))
 
     if (is.null(strata) || length(unique(strata)) == 1) {
       r_diff <- (x1 / n1 - x0 / n0)
-      chisq_obs <- (r_diff - d)^2 / vart
+      chisq_obs <- if (isTRUE(r_diff == d) && isTRUE(vart == 0)) {
+        0
+      } else {
+        (r_diff - d)^2 / vart
+      }
     }
     if (!length(unique(strata)) == 1) {
       # Start to calculate the Chi-square
@@ -368,7 +383,11 @@ rate_compare_sum <- function(
       vs <- sum(var_w)
 
       r_diff <- sum(r1_w) - sum(r0_w)
-      chisq_obs <- (r_diff - d)^2 / vs
+      chisq_obs <- if (isTRUE(r_diff == d) && isTRUE(vs == 0)) {
+        0
+      } else {
+        (r_diff - d)^2 / vs
+      }
     }
     return(chisq_obs - qchisq(1 - alpha, 1))
   }

--- a/tests/testthat/_snaps/independent-testing-tlf_ae_specific/diednp_ae0specific1.rtf
+++ b/tests/testthat/_snaps/independent-testing-tlf_ae_specific/diednp_ae0specific1.rtf
@@ -109,10 +109,10 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1286
@@ -351,8 +351,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1286
@@ -575,8 +575,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1286
@@ -695,8 +695,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx1286
@@ -855,8 +855,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 
 
@@ -959,8 +959,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx1286
@@ -999,8 +999,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000

--- a/tests/testthat/_snaps/independent-testing-tlf_ae_specific/diednpt_ae0specific1.rtf
+++ b/tests/testthat/_snaps/independent-testing-tlf_ae_specific/diednpt_ae0specific1.rtf
@@ -127,10 +127,10 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx849
@@ -417,8 +417,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 
 
@@ -683,8 +683,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx849
@@ -827,8 +827,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx849
@@ -1093,8 +1093,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx849
@@ -1141,8 +1141,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx849
@@ -1189,8 +1189,8 @@
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (-x.x,  x.x)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  x.xxx}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b   x.x}\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b }\cell
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b (-x.x,  x.x)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0\b  x.xxx}\cell
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000

--- a/tests/testthat/test-independent-testing-rate_compare_sum.R
+++ b/tests/testthat/test-independent-testing-rate_compare_sum.R
@@ -98,3 +98,46 @@ test_that("match with rate_compare()", {
   expect_equal(xx_output, yy_output, tolerance = 1e-4)
   expect_equal(colnames(xx), colnames(yy))
 })
+
+test_that("return MN confidence interval when both event counts are zero", {
+  result <- rate_compare_sum(n0 = 105, n1 = 101, x0 = 0, x1 = 0)
+
+  expect_equal(result$est, 0)
+  expect_equal(result$z_score, 0)
+  expect_equal(result$p, 1)
+  expect_true(all(is.finite(c(result$lower, result$upper))))
+  expect_lt(result$lower, 0)
+  expect_gt(result$upper, 0)
+  expect_equal(result$lower, -0.03547636, tolerance = 1e-3)
+  expect_equal(result$upper, 0.03683015, tolerance = 1e-3)
+})
+
+test_that("zero-event confidence interval gets tighter with larger samples", {
+  small <- rate_compare_sum(n0 = 10, n1 = 20, x0 = 0, x1 = 0)
+  large <- rate_compare_sum(n0 = 105, n1 = 101, x0 = 0, x1 = 0)
+
+  expect_true(all(is.finite(c(small$lower, small$upper))))
+  expect_gt(small$upper - small$lower, large$upper - large$lower)
+})
+
+test_that("single-arm zero events still return finite results", {
+  result <- rate_compare_sum(n0 = 105, n1 = 101, x0 = 0, x1 = 1)
+
+  expect_true(all(is.finite(unlist(result))))
+})
+
+test_that("NA inputs still return an NA row", {
+  result <- rate_compare_sum(n0 = NA, n1 = 101, x0 = 0, x1 = 0)
+
+  expect_true(all(is.na(unlist(result))))
+})
+
+test_that("zero-event strata contribute to a stratified analysis", {
+  result <- rate_compare_sum(
+    n0 = c(50, 55), n1 = c(50, 51),
+    x0 = c(0, 4), x1 = c(0, 8),
+    strata = c("a", "b")
+  )
+
+  expect_true(all(is.finite(unlist(result))))
+})


### PR DESCRIPTION
Fixes #210

## Summary
- `rate_compare_sum()` now returns Miettinen & Nurminen estimate and score CI when both arms have 0 events, instead of `NA`
- Removes `all(c(x0,x1)==0)` early-return; keeps `NA` guard only for `NA` inputs
- Adds constrained-MLE clamping for `r0t` and zero-variance handling for `z_score`/`chisq_obs` so 0/0 inverts correctly (est=0, z=0, p=1)

## Rationale
MN interval is defined at 0/0 via score inversion (paper example 4; `sasLM::RDmn1(0,10,0,20)` → [-0.166, 0.284], `gsDesign::ciBinomial(0,0,10,20)` similar). Returning `NA` is inconsistent with the method and hides valid bounding information on absolute risk difference. Larger `n` ⇒ tighter CI is informative (e.g. 105/101 → [-0.035, 0.037] vs 10/20 → width 0.45). Display suppression for uninformative rows belongs in table formatters, not the estimator. Aligns with SAS/gsDesign.

## Verification
- Manual: `rate_compare_sum(105,101,0,0)` → `0 [-0.03546, 0.03681] p=1` (≈ sasLM -0.03547/0.03683, tol 1e-3)
- Manual: `rate_compare_sum(10,20,0,0)` width < large-sample width ✓ ; stratified 0/0 stratum contributes ✓
- `testthat::test_file(test-independent-testing-rate_compare_sum.R)` → 14 passed, 1 skipped (DescTools missing)

## Tests
Added 5 cases in `test-independent-testing-rate_compare_sum.R`:
- 0/0 returns 0/p=1/finite CI matching sasLM
- CI tightens with n
- single-arm zero still finite
- NA input → NA row
- stratified with 0/0 stratum still finite
